### PR TITLE
Backtrace code preview refactored

### DIFF
--- a/src/components/catalog/catchers/guides/php.vue
+++ b/src/components/catalog/catchers/guides/php.vue
@@ -54,10 +54,7 @@
           <p>
             Create an instance with Token at the entry point of your project.
           </p>
-          <CodeBlock
-            one-line
-            copyable
-          >
+          <CodeBlock copyable>
             \Hawk\HawkCatcher::instance('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1NjMyNjQ1NTd9.GTP');
           </CodeBlock>
           <h3>Enable handlers</h3>

--- a/src/components/events/DetailsBacktrace.vue
+++ b/src/components/events/DetailsBacktrace.vue
@@ -41,10 +41,10 @@
             class="details-backtrace__arrow-down"
           />
         </div>
-        <CodePreview
+        <CodeFragment
           v-if="openedFrames.includes(index) && frame.sourceCode"
+          :lines="frame.sourceCode"
           :lines-highlighted="[frame.line]"
-          :frames="frame.sourceCode"
           :lang="lang"
         />
       </div>
@@ -57,14 +57,14 @@
 
 <script>
 import DetailsBase from './DetailsBase';
-import CodePreview from '../utils/CodePreview';
+import CodeFragment from '../utils/CodeFragment';
 import Icon from '../utils/Icon';
 
 export default {
   name: 'DetailsBacktrace',
   components: {
     DetailsBase,
-    CodePreview,
+    CodeFragment,
     Icon
   },
   props: {

--- a/src/components/events/DetailsBacktrace.vue
+++ b/src/components/events/DetailsBacktrace.vue
@@ -36,20 +36,18 @@
           </div>
           <Icon
             v-if="bt.sourceCode"
-            :class="{'details-backtrace__arrow-down--opened': openedFilesView.includes(index) && bt.sourceCode}"
+            :class="{'details-backtrace__arrow-down--opened': openedFrames.includes(index) && bt.sourceCode}"
             symbol="arrow-down"
             class="details-backtrace__arrow-down"
           />
         </div>
-        <CodeBlock
-          v-if="openedFilesView.includes(index) && bt.sourceCode"
-          show-lines-numbers
-          :lines-from="bt.sourceCode[0].line"
-          :highlight-lines="bt.line"
-          class="details-backtrace__source-code"
+        <CodePreview
+          v-if="openedFrames.includes(index) && bt.sourceCode"
+          :lines-highlighted="[bt.line]"
+          :frames="bt.sourceCode"
+          lang="javascript"
         >
-          <pre>{{ joinSourceCodeLines(bt.sourceCode) }}</pre>
-        </CodeBlock>
+        </CodePreview>
       </div>
     </template>
     <template #expandButton>
@@ -60,14 +58,14 @@
 
 <script>
 import DetailsBase from './DetailsBase';
-import CodeBlock from '../utils/CodeBlock';
+import CodePreview from '../utils/CodePreview';
 import Icon from '../utils/Icon';
 
 export default {
   name: 'DetailsBacktrace',
   components: {
     DetailsBase,
-    CodeBlock,
+    CodePreview,
     Icon
   },
   props: {
@@ -85,7 +83,12 @@ export default {
        * Is block expanded.
        */
       isMoreFilesShown: false,
-      openedFilesView: []
+
+      /**
+       * Indexes of opened frames
+       * By default, open first frame
+       */
+      openedFrames: [ 0 ]
     };
   },
   computed: {
@@ -113,12 +116,12 @@ export default {
      * @param {Number} index - backtrace info index
      */
     toggleViewState(index) {
-      if (this.openedFilesView.includes(index)) {
-        const itemIndex = this.openedFilesView.indexOf(index);
+      if (this.openedFrames.includes(index)) {
+        const itemIndex = this.openedFrames.indexOf(index);
 
-        this.openedFilesView.splice(itemIndex, 1);
+        this.openedFrames.splice(itemIndex, 1);
       } else {
-        this.openedFilesView.push(index);
+        this.openedFrames.push(index);
       }
     }
   }

--- a/src/components/events/DetailsBacktrace.vue
+++ b/src/components/events/DetailsBacktrace.vue
@@ -9,7 +9,7 @@
     </template>
     <template #content>
       <div
-        v-for="(bt, index) in filteredBacktrace"
+        v-for="(frame, index) in filteredBacktrace"
         :key="index"
         class="event-details__content-block details-backtrace__content-block"
       >
@@ -18,8 +18,8 @@
           @click="toggleViewState(index)"
         >
           <div class="details-backtrace__left">
-            <span v-if="bt.function">
-              {{ bt.function }}
+            <span v-if="frame.function">
+              {{ frame.function }}
             </span>
             <span
               v-else
@@ -29,25 +29,24 @@
             </span>
           </div>
           <div class="details-backtrace__right">
-            {{ bt.file }}
-            <template v-if="bt.line">
-              line {{ bt.line }}<template v-if="bt.column">:{{ bt.column }}</template>
+            {{ frame.file }}
+            <template v-if="frame.line">
+              line {{ getLocation(frame) }}
             </template>
           </div>
           <Icon
-            v-if="bt.sourceCode"
-            :class="{'details-backtrace__arrow-down--opened': openedFrames.includes(index) && bt.sourceCode}"
+            v-if="frame.sourceCode"
+            :class="{'details-backtrace__arrow-down--opened': openedFrames.includes(index) && frame.sourceCode}"
             symbol="arrow-down"
             class="details-backtrace__arrow-down"
           />
         </div>
         <CodePreview
-          v-if="openedFrames.includes(index) && bt.sourceCode"
-          :lines-highlighted="[bt.line]"
-          :frames="bt.sourceCode"
-          lang="javascript"
-        >
-        </CodePreview>
+          v-if="openedFrames.includes(index) && frame.sourceCode"
+          :lines-highlighted="[frame.line]"
+          :frames="frame.sourceCode"
+          :lang="lang"
+        />
       </div>
     </template>
     <template #expandButton>
@@ -75,6 +74,14 @@ export default {
     backtrace: {
       type: Array,
       required: true
+    },
+
+    /**
+     * Error environment language
+     */
+    lang: {
+      type: String,
+      default: undefined
     }
   },
   data() {
@@ -98,7 +105,7 @@ export default {
       return this.backtrace.length === 4 || this.isMoreFilesShown ? this.backtrace : this.backtrace.slice(0, 3);
     }
   },
-  mounted(){
+  mounted() {
     /**
      * By default, open first frame that has a source code
      */
@@ -128,6 +135,23 @@ export default {
       } else {
         this.openedFrames.push(index);
       }
+    },
+
+    /**
+     * Return concatenated "line:column" with the necessary checkups
+     *
+     * @param {number} line - calling line number
+     * @param {number} [column] - calling column number
+     * @return {string}
+     */
+    getLocation({ line, column }) {
+      let str = line;
+
+      if (!isNaN(parseInt(column))) {
+        str += ':' + column;
+      }
+
+      return str;
     }
   }
 };

--- a/src/components/events/DetailsBacktrace.vue
+++ b/src/components/events/DetailsBacktrace.vue
@@ -86,9 +86,8 @@ export default {
 
       /**
        * Indexes of opened frames
-       * By default, open first frame
        */
-      openedFrames: [ 0 ]
+      openedFrames: []
     };
   },
   computed: {
@@ -98,6 +97,12 @@ export default {
     filteredBacktrace() {
       return this.backtrace.length === 4 || this.isMoreFilesShown ? this.backtrace : this.backtrace.slice(0, 3);
     }
+  },
+  mounted(){
+    /**
+     * By default, open first frame that has a source code
+     */
+    this.openedFrames.push(this.backtrace.findIndex(frame => !!frame.sourceCode));
   },
   methods: {
     /**

--- a/src/components/events/Overview.vue
+++ b/src/components/events/Overview.vue
@@ -50,6 +50,7 @@
           v-if="event.payload.backtrace && event.payload.backtrace.length"
           class="event-overview__section"
           :backtrace="event.payload.backtrace"
+          :lang="lang"
         />
         <DetailsCookie
           v-if="event.payload.cookies && event.payload.cookies.length"
@@ -86,6 +87,17 @@ export default {
       event: null,
       projectId
     };
+  },
+  computed: {
+    /**
+     * Get calling env language based on event.catcherType
+     * errors/javascript -> javascript
+     *
+     * @return {string}
+     */
+    lang() {
+      return this.event.catcherType.split('/').pop();
+    }
   },
   /**
    * Vue created hook. Fetchs error's data

--- a/src/components/projects/TokenBlock.vue
+++ b/src/components/projects/TokenBlock.vue
@@ -1,7 +1,6 @@
 <template>
   <CodeBlock
     language="plaintext"
-    one-line
     copyable
     class="project-token-block"
   >

--- a/src/components/utils/CodeBlock.vue
+++ b/src/components/utils/CodeBlock.vue
@@ -46,7 +46,7 @@ export default {
     /**
      * Return true if there is a single line of a code
      */
-    isSingleLine(){
+    isSingleLine() {
       return this.$slots.default[0].text.includes('\n') === false;
     }
   },
@@ -94,9 +94,9 @@ export default {
     &--one-line {
       ^&__content {
         @apply --hide-scrollbar;
+        height: 1em;
         overflow: hidden;
         white-space: nowrap;
-        height: 1em;
       }
 
       ^&__button-wrapper {

--- a/src/components/utils/CodeBlock.vue
+++ b/src/components/utils/CodeBlock.vue
@@ -45,6 +45,7 @@ export default {
   computed: {
     /**
      * Return true if there is a single line of a code
+     * @return {boolean}
      */
     isSingleLine() {
       return this.$slots.default[0].text.includes('\n') === false;

--- a/src/components/utils/CodeBlock.vue
+++ b/src/components/utils/CodeBlock.vue
@@ -2,25 +2,12 @@
   <div
     v-copyable="{selector: copyable? '.code-block__content' : null, callback: onLinkCopied}"
     class="code-block"
-    :class="{'code-block--one-line': oneLine, 'code-block--copyable': copyable}"
+    :class="{'code-block--one-line': isSingleLine, 'code-block--copyable': copyable}"
   >
-    <div
-      v-if="showLinesNumbers"
-      class="code-block__line-numbers-container"
-    >
-      <div
-        v-for="lineNumber in linesNumber"
-        :key="lineNumber"
-        class="code-block__line-number"
-        :class="{'code-block__line-number--highlighted': highlightLines === linesFrom + lineNumber - 1}"
-      >
-        {{ linesFrom + lineNumber - 1 }}
-      </div>
-    </div>
     <div
       ref="content"
       class="code-block__content"
-      :class="{[language]: language}"
+      :class="{[language]: true}"
     >
       <slot />
     </div>
@@ -30,7 +17,7 @@
         class="button button--copy code-block__copy-button"
         type="button"
       >
-        {{ $t('workspaces.settings.team.copyButton') }}
+        {{ $t('components.codeBlock.copy') }}
       </button>
     </div>
   </div>
@@ -47,22 +34,21 @@ export default {
       type: String,
       default: null
     },
-    linesFrom: {
-      type: Number,
-      default: 0
-    },
-    highlightLines: {
-      type: [Number, Array],
-      default: null
-    },
     copyable: Boolean,
-    showLinesNumbers: Boolean,
     oneLine: Boolean
   },
   data() {
     return {
       linesNumber: 0
     };
+  },
+  computed: {
+    /**
+     * Return true if there is a single line of a code
+     */
+    isSingleLine(){
+      return this.$slots.default[0].text.includes('\n') === false;
+    }
   },
   /**
    * Vue mounted hook. Used to render highlighting
@@ -98,30 +84,6 @@ export default {
     border: solid 1px rgba(0, 0, 0, 0.18);
     border-radius: 6px;
 
-    &__line-numbers-container {
-      margin-right: 7px;
-      color: var(--color-text-second);
-      font-size: 10px;
-      font-family: var(--font-monospace);
-      text-align: right;
-    }
-
-    &__line-number {
-      &--highlighted {
-        &::before {
-          position: absolute;
-          right: 0;
-          left: 0;
-          display: block;
-          height: 21px;
-          background-color: rgba(255, 115, 212, 0.18);
-          transform: translateY(-1px);
-          content: '';
-          pointer-events: none;
-        }
-      }
-    }
-
     &__content {
       position: relative;
       width: 100%;
@@ -131,9 +93,10 @@ export default {
 
     &--one-line {
       ^&__content {
+        @apply --hide-scrollbar;
         overflow: hidden;
         white-space: nowrap;
-        @apply --hide-scrollbar;
+        height: 1em;
       }
 
       ^&__button-wrapper {
@@ -148,93 +111,7 @@ export default {
       right: 0;
       padding-right: 15px;
       padding-left: 30px;
-      background-image: linear-gradient(to right, var(--color-bg-main-transparent), var(--color-bg-main) 20%)
+      background-image: linear-gradient(to right, var(--color-bg-main-transparent), var(--color-bg-main) 20%);
     }
   }
-
-  .hljs {
-    display: block;
-    overflow-x: auto;
-  }
-
-  .hljs,
-  .hljs-subst {
-    color: var(--color-text-main);
-  }
-
-  .hljs-comment {
-    color: #888888;
-  }
-
-  .hljs-keyword,
-  .hljs-attribute,
-  .hljs-selector-tag,
-  .hljs-meta-keyword,
-  .hljs-doctag,
-  .hljs-name {
-    font-weight: bold;
-  }
-
-  /* User color: hue: 0 */
-
-  .hljs-type,
-  .hljs-string,
-  .hljs-number,
-  .hljs-selector-id,
-  .hljs-selector-class,
-  .hljs-quote,
-  .hljs-template-tag,
-  .hljs-deletion {
-    color: var(--color-text-second);
-  }
-
-  .hljs-title,
-  .hljs-section {
-    color: #880000;
-    font-weight: bold;
-  }
-
-  .hljs-regexp,
-  .hljs-symbol,
-  .hljs-variable,
-  .hljs-template-variable,
-  .hljs-link,
-  .hljs-selector-attr,
-  .hljs-selector-pseudo {
-    color: #BC6060;
-  }
-
-  /* Language color: hue: 90; */
-
-  .hljs-literal {
-    color: #78A960;
-  }
-
-  .hljs-built_in,
-  .hljs-bullet,
-  .hljs-code,
-  .hljs-addition {
-    color: #397300;
-  }
-
-  /* Meta color: hue: 200 */
-
-  .hljs-meta {
-    color: #1f7199;
-  }
-
-  .hljs-meta-string {
-    color: #4d99bf;
-  }
-
-  /* Misc effects */
-
-  .hljs-emphasis {
-    font-style: italic;
-  }
-
-  .hljs-strong {
-    font-weight: bold;
-  }
-
 </style>

--- a/src/components/utils/CodeFragment.vue
+++ b/src/components/utils/CodeFragment.vue
@@ -4,14 +4,14 @@
     class="code-preview"
   >
     <pre
-      v-for="line in lines"
-      :key="line.line"
+      v-for="row in lines"
+      :key="row.line"
       class="code-preview__line"
-      :class="{'code-preview__line--current': isCurrentLine(line.line), [syntax]: true }"
+      :class="{'code-preview__line--current': isCurrentLine(row.line), [syntax]: true }"
     ><span
 class="code-preview__line-num"
-           :data-line="line.line"
-    /><code>{{ line.content }}</code></pre>
+           :data-line="row.line"
+    /><code>{{ row.content }}</code></pre>
   </div>
 </template>
 

--- a/src/components/utils/CodeFragment.vue
+++ b/src/components/utils/CodeFragment.vue
@@ -1,14 +1,17 @@
 <template>
   <div
-    class="code-preview"
     ref="content"
+    class="code-preview"
   >
     <pre
       v-for="line in lines"
       :key="line.line"
       class="code-preview__line"
       :class="{'code-preview__line--current': isCurrentLine(line.line), [syntax]: true }"
-    ><span class="code-preview__line-num" :data-line="line.line"></span><code>{{ line.content }}</code></pre>
+    ><span
+class="code-preview__line-num"
+           :data-line="line.line"
+    /><code>{{ line.content }}</code></pre>
   </div>
 </template>
 
@@ -148,9 +151,9 @@ export default {
         display: inline-block;
         width: 35px;
         padding: 0 10px;
+        color: var(--color-text-main);
         font-size: 10px;
         vertical-align: bottom;
-        color: var(--color-text-main);
         opacity: 0.4;
 
         &::before {

--- a/src/components/utils/CodePreview.vue
+++ b/src/components/utils/CodePreview.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="code-preview" ref="content" :class="lang">
+  <div
+    ref="content"
+    class="code-preview"
+    :class="lang"
+  >
     <pre
       v-for="frame in frames"
       :key="frame.line"
@@ -21,7 +25,7 @@ export default {
      */
     frames: {
       type: Array,
-      default(){
+      default() {
         return [];
       }
     },
@@ -43,6 +47,14 @@ export default {
       default: 'plaintext'
     }
   },
+  /**
+   * Vue mounted hook. Used to render highlighting
+   */
+  mounted() {
+    if (this.lang !== 'plaintext') {
+      hljs.highlightBlock(this.$refs.content);
+    }
+  },
   methods: {
     /**
      * Check if passed line should be highlighted
@@ -52,15 +64,7 @@ export default {
     isCurrentLine(line) {
       return this.linesHighlighted.includes(line);
     }
-  },
-  /**
-   * Vue mounted hook. Used to render highlighting
-   */
-  mounted() {
-    if (this.lang !== 'plaintext') {
-      hljs.highlightBlock(this.$refs.content);
-    }
-  },
+  }
 };
 </script>
 
@@ -68,9 +72,9 @@ export default {
   @import "../../styles/custom-properties.css";
 
   .code-preview {
+    font-family: var(--font-monospace);
     background-color: #171920;
     border-radius: var(--border-radius);
-    font-family: var(--font-monospace);
 
     &__line {
       display: flex;

--- a/src/components/utils/CodePreview.vue
+++ b/src/components/utils/CodePreview.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="code-preview" ref="content" :class="lang">
+    <pre
+      v-for="frame in frames"
+      :key="frame.line"
+      class="code-preview__line"
+      :class="{'code-preview__line--current': isCurrentLine(frame.line)}"
+    ><span class="code-preview__line-num">{{ frame.line }}</span>{{ frame.content }}</pre>
+  </div>
+</template>
+
+<script>
+import hljs from 'highlight.js';
+
+export default {
+  name: 'CodePreview',
+  props: {
+    /**
+     * Array fo stack frames
+     * @type {{line: number, content: string}[]}
+     */
+    frames: {
+      type: Array,
+      default(){
+        return [];
+      }
+    },
+
+    /**
+     * Array of line numbers that should be highlighted
+     * @type {number[]}
+     */
+    linesHighlighted: {
+      type: Array,
+      default: null
+    },
+
+    /**
+     * Code language
+     */
+    lang: {
+      type: String,
+      default: 'plaintext'
+    }
+  },
+  methods: {
+    /**
+     * Check if passed line should be highlighted
+     * @param {number} line - line to check
+     * @return {boolean}
+     */
+    isCurrentLine(line) {
+      return this.linesHighlighted.includes(line);
+    }
+  },
+  /**
+   * Vue mounted hook. Used to render highlighting
+   */
+  mounted() {
+    if (this.lang !== 'plaintext') {
+      hljs.highlightBlock(this.$refs.content);
+    }
+  },
+};
+</script>
+
+<style>
+  @import "../../styles/custom-properties.css";
+
+  .code-preview {
+    background-color: #171920;
+    border-radius: var(--border-radius);
+    font-family: var(--font-monospace);
+
+    &__line {
+      display: flex;
+      font-size: 12px;
+      line-height: 21px;
+
+      &--current {
+        background-color: rgba(255, 115, 212, 0.18);
+      }
+
+      &-num {
+        display: inline-block;
+        width: 35px;
+        padding: 0 10px;
+        font-size: 10px;
+        vertical-align: bottom;
+      }
+    }
+  }
+
+</style>

--- a/src/components/utils/CodePreview.vue
+++ b/src/components/utils/CodePreview.vue
@@ -18,15 +18,6 @@ import hljs from 'highlight.js';
 
 export default {
   name: 'CodePreview',
-  data(){
-    return {
-      /**
-       * Highlighting syntax.
-       * Can be overridden in some cases, {@link mounted}
-       */
-      syntax: null
-    };
-  },
   props: {
     /**
      * Array fo stack frames
@@ -55,6 +46,15 @@ export default {
       type: String,
       default: 'plaintext'
     }
+  },
+  data() {
+    return {
+      /**
+       * Highlighting syntax.
+       * Can be overridden in some cases, {@link mounted}
+       */
+      syntax: null
+    };
   },
   /**
    * Vue mounted hook. Used to render highlighting

--- a/src/components/workspaces/Team.vue
+++ b/src/components/workspaces/Team.vue
@@ -36,7 +36,7 @@
         <input
           type="button"
           class="workspace-team__copy-button"
-          :value="$t('workspaces.settings.team.copyButton')"
+          :value="$t('components.codeBlock.copy')"
         >
       </div>
     </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -19,6 +19,9 @@
       "en": "English",
       "label": "Interface Language",
       "ru": "Russian"
+    },
+    "codeBlock": {
+      "copy": "COPY"
     }
   },
   "forms": {
@@ -87,7 +90,6 @@
         "inviteByEmailLabel": "Invite by email",
         "sendButton": "Send",
         "inviteByLinkLabel": "Invite by link",
-        "copyButton": "COPY",
         "youLabel": "you",
         "adminLabel": "Admin",
         "invitationSentLabel": "invitation sent",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -19,6 +19,9 @@
       "en": "Английский",
       "label": "Язык интерфейса",
       "ru": "Русский"
+    },
+    "codeBlock": {
+      "copy": "СКОПИРОВАТЬ"
     }
   },
   "forms": {
@@ -87,7 +90,6 @@
         "inviteByEmailLabel": "Пригласить по email",
         "sendButton": "Отправить",
         "inviteByLinkLabel": "Пригласить по ссылке",
-        "copyButton": "Скопировать",
         "youLabel": "вы",
         "adminLabel": "Администратор",
         "invitationSentLabel": "приглашение отправлено",

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,5 +1,6 @@
 @import "normalize.css";
 @import "variables.css";
+@import "code-highlighting.css";
 
 /**
  * Base site styles

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -128,8 +128,8 @@ pre {
   }
 
   &--copy {
-    height: 23px;
-    padding: 0 15px;
+    height: 22px;
+    padding: 0 13px;
     color: var(--color-text-main);
     font-size: 11px;
     line-height: 23px;

--- a/src/styles/code-highlighting.css
+++ b/src/styles/code-highlighting.css
@@ -1,0 +1,84 @@
+.hljs {
+  display: block;
+  overflow-x: auto;
+}
+
+.hljs,
+.hljs-subst {
+  color: var(--color-text-main);
+}
+
+.hljs-comment {
+  color: #888888;
+}
+
+.hljs-keyword,
+.hljs-attribute,
+.hljs-selector-tag,
+.hljs-meta-keyword,
+.hljs-doctag,
+.hljs-name {
+  font-weight: bold;
+}
+
+/* User color: hue: 0 */
+
+.hljs-type,
+.hljs-string,
+.hljs-number,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-quote,
+.hljs-template-tag,
+.hljs-deletion {
+  color: var(--color-text-second);
+}
+
+.hljs-title,
+.hljs-section {
+  color: #880000;
+  font-weight: bold;
+}
+
+.hljs-regexp,
+.hljs-symbol,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-link,
+.hljs-selector-attr,
+.hljs-selector-pseudo {
+  color: #BC6060;
+}
+
+/* Language color: hue: 90; */
+
+.hljs-literal {
+  color: #78A960;
+}
+
+.hljs-built_in,
+.hljs-bullet,
+.hljs-code,
+.hljs-addition {
+  color: #397300;
+}
+
+/* Meta color: hue: 200 */
+
+.hljs-meta {
+  color: #1f7199;
+}
+
+.hljs-meta-string {
+  color: #4d99bf;
+}
+
+/* Misc effects */
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/src/styles/code-highlighting.css
+++ b/src/styles/code-highlighting.css
@@ -18,7 +18,15 @@
 .hljs-meta-keyword,
 .hljs-doctag,
 .hljs-name {
-  font-weight: bold;
+  color: #e961d0;
+}
+
+.hljs-attr {
+  color: #f5d50e;
+}
+
+.hljs-params {
+  color: #f08a1e;
 }
 
 /* User color: hue: 0 */
@@ -31,13 +39,12 @@
 .hljs-quote,
 .hljs-template-tag,
 .hljs-deletion {
-  color: var(--color-text-second);
+  color: #2ccf6c;
 }
 
 .hljs-title,
 .hljs-section {
-  color: #880000;
-  font-weight: bold;
+  color: #27a4ef;
 }
 
 .hljs-regexp,

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -21,8 +21,13 @@
   --color-border-input: #1f2230;
   --color-border: rgba(219, 230, 255, 0.2);
 
-  --font-monospace: SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier,
-    monospace;
+  --font-monospace: SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier, monospace;
+
+  /**
+   * Code fragment colors
+   */
+  --color-bg-code-fragment: #171920;
+  --color-bg-code-fragment-line-highlighted: rgba(255, 7, 172, 0.12);
 }
 
 .app--theme--light {


### PR DESCRIPTION
For now, in master, we have a single component for simple code blocks (for example for Integration Token) and for Backtrace preview. It is complicated, so I've created two simple separated components.

<img width="1224" alt="image" src="https://user-images.githubusercontent.com/3684889/70849086-f3091400-1e8a-11ea-9eaa-aedcc4a92348.png">

<img width="1098" alt="image" src="https://user-images.githubusercontent.com/3684889/70849088-fef4d600-1e8a-11ea-8117-e6e7a6ba3f82.png">

### Also

- code highlighting has been improved. 
- the first available backtrace preview is now opened by default
