### PR TITLE
Improvements/whole code highlighting

### DIFF
--- a/src/components/utils/CodeFragment.vue
+++ b/src/components/utils/CodeFragment.vue
@@ -3,20 +3,18 @@
     ref="content"
     class="code-preview"
   >
+    <div class="code-preview__lines">
+      <span
+        v-for="row in lines"
+        :key="row.line"
+        :data-line="row.line"
+      />
+    </div>
     <pre
-      v-for="row in lines"
-      :key="row.line"
-      class="code-preview__line"
-      :class="{'code-preview__line--current': isCurrentLine(row.line), [syntax]: true }"
-    ><span
-      class="code-preview__line-num"
-     :data-line="row.line"
-    /><code v-html="contentWithPointer(row)" /></pre>
-
-    <!--        <pre-->
-    <!--          class="code-preview__content"-->
-    <!--          :class="{[syntax]: true }"-->
-    <!--        >{{ checkComment(code)}}</pre>-->
+      class="code-preview__content"
+      :class="{[syntax]: true }"
+      v-html="escapedCodeWithPointer"
+    ></pre>
   </div>
 </template>
 
@@ -96,8 +94,27 @@ export default {
      */
     code() {
       return this.lines.map(line => line.content).join('\n');
-    }
+    },
 
+    /**
+     * Prepare and return html-escaped code with the column pointer for highlighted line
+     * @return {string}
+     */
+    escapedCodeWithPointer(){
+      const code = this.fixUnclosedComment(this.code);
+
+      /**
+       * Add column pointer to the specific line and column
+       */
+      const lineIndex = this.lines.map(row => row.line).indexOf(this.linesHighlighted[0]);
+      const offset = _.findOffsetByLineAndCol(code, lineIndex, this.columnPointer);
+
+      if (offset) {
+        return this.addColumnPointerToStringEscaped(code, offset);
+      }
+
+      return _.escape(code);
+    }
   },
   /**
    * Vue mounted hook. Used to render highlighting
@@ -173,69 +190,80 @@ export default {
     },
 
     /**
-     * Prepare and return code row with the column pointer for current line
-     * @param {CodeRow} row - one row of a code
+     * Adds column pointer to the string with escaping-chars offset support
+     *
+     * @param {string} string - unescaped string
+     * @param {number} position - original column number, before escape
      * @return {string}
      */
-    contentWithPointer(row) {
-      if (!this.isCurrentLine(row.line)) {
-        return _.escape(row.content);
-      }
+    addColumnPointerToStringEscaped(string, position) {
+      const contentEscaped = _.escape(string);
+      const leftPartEscaped = _.escape(string.substr(0, position), true);
 
-      if (this.columnPointer) {
-        const contentEscaped = _.escape(row.content);
-        const leftPartEscaped = _.escape(row.content.substr(0, this.columnPointer), true);
+      /**
+       * If there are some escaping symbols added before the column-pointer,
+       * we need to increase real column for this number of symbols.
+       */
+      const newColumnPosition = leftPartEscaped.count === 0 ? position : position + leftPartEscaped.length;
 
+      return _.strReplaceAt(
+        contentEscaped,
+        newColumnPosition,
+        `<span class="column-pointer">${contentEscaped[newColumnPosition]}</span>`
+      );
+    },
+
+    /**
+     * If the code fragment start with trimmed comment,
+     * add opening comment chars to prevent breaking of highlighting.
+     *
+     * @param {string} code
+     */
+    fixUnclosedComment(code){
+      const lines = code.split('\n').map(line => line.trim());
+      const firstLine = lines.shift();
+
+      /**
+       * If code fragment starts with "* /" we need to add opening comment and the second *
+       */
+      if (firstLine.substr(0, 2) === '*/'){
+        code = code.replace(/\s?\*/, '/* … *');
         /**
-         * If there are some escaping symbols added before the column-pointer,
-         * we need to increase real column for this number of symbols.
-         * Also, do -1 decrement, because of the line-break char, so real position starts from 1 instead of 0
+         * Case when the fragment start with *
          */
-        const columnWithEscapedCharsLength = leftPartEscaped.count === 0 ? this.columnPointer : this.columnPointer + leftPartEscaped.length - 1;
-
-        return _.strReplaceAt(contentEscaped, columnWithEscapedCharsLength, `<span class="column-pointer">${contentEscaped[columnWithEscapedCharsLength]}</span>`);
+      } else if (firstLine.substr(0, 1) === '*'){
+        code = code.replace(/\s?\*/, '/* … ');
       }
-      return row.content;
-    }
 
-    // checkComment(code){
-    //   let lines = code.split('\n').map(line => line.trim());
-    //
-    //   console.log('lines', lines);
-    //
-    //   if (lines && lines[0].substr(0, 1) === '*'){
-    //     return code.replace(/\s?\*/, '/* ...');
-    //   }
-    //   return code;
-    // }
+      return code;
+    }
   }
 };
 </script>
 
 <style>
   .code-preview {
+    display: flex;
     font-family: var(--font-monospace);
     background-color: var(--color-bg-code-fragment);
     border-radius: var(--border-radius);
 
     &__content {
+      flex-grow: 2;
       font-size: 12px;
       line-height: 21px;
     }
 
-    &__line {
+    &__lines {
       display: flex;
-      overflow: visible;
-      font-size: 12px;
-      line-height: 21px;
+      flex-direction: column;
+      width: 35px;
 
-      &--current {
-        background-color: var(--color-bg-code-fragment-line-highlighted);
-      }
-
-      &-num {
-        display: inline-block;
-        width: 35px;
+      span {
+        flex-grow: 1;
+        display: flex;
+        line-height: 21px;
+        align-items: center;
         padding: 0 10px;
         color: var(--color-text-main);
         font-size: 10px;
@@ -246,22 +274,33 @@ export default {
           content: attr(data-line)
         }
       }
+    }
 
-      .column-pointer {
-        position: relative;
+    .column-pointer {
+      position: relative;
 
-        &::after {
-          position: absolute;
-          top: calc(100% + 3px);
-          left: 1px;
-          width: 6px;
-          height: 6px;
-          border: 2px solid var(--color-code-pointer);
-          border-width: 2px 2px 0 0;
-          box-shadow: 1px -1px 4px color-mod(var(--color-code-pointer) alpha(40%));
-          transform: rotate(-45deg);
-          content: '';
-        }
+      &::after {
+        position: absolute;
+        top: calc(100% + 3px);
+        left: 1px;
+        width: 6px;
+        height: 6px;
+        border: 2px solid var(--color-code-pointer);
+        border-width: 2px 2px 0 0;
+        box-shadow: 1px -1px 4px color-mod(var(--color-code-pointer) alpha(40%));
+        transform: rotate(-45deg);
+        content: '';
+      }
+    }
+
+    &__line {
+      display: flex;
+      overflow: visible;
+      font-size: 12px;
+      line-height: 21px;
+
+      &--current {
+        background-color: var(--color-bg-code-fragment-line-highlighted);
       }
     }
   }

--- a/src/components/utils/CodeFragment.vue
+++ b/src/components/utils/CodeFragment.vue
@@ -111,11 +111,14 @@ export default {
       const code = this.fixUnclosedComment(this.code);
 
       /**
-       * Add column pointer to the specific line and column
+       * To add column pointer, we need to compute real offset from the start of code, not just a current line.
        */
       const lineIndex = this.lines.map(row => row.line).indexOf(this.linesHighlighted[0]);
       const offset = _.findOffsetByLineAndCol(code, lineIndex, this.columnPointer);
 
+      /**
+       * Add column pointer to the specific line and column
+       */
       if (offset) {
         return this.addColumnPointerToStringEscaped(code, offset);
       }

--- a/src/components/utils/CodeFragment.vue
+++ b/src/components/utils/CodeFragment.vue
@@ -10,6 +10,13 @@
         :data-line="row.line"
       />
     </div>
+    <div class="code-preview__rows">
+      <div
+        v-for="row in lines"
+        :key="row.line"
+        :class="{'current': isCurrentLine(row.line)}"
+      />
+    </div>
     <pre
       class="code-preview__content"
       :class="{[syntax]: true }"
@@ -184,6 +191,7 @@ export default {
 
     /**
      * Check if current code fragment is a TypeScript code
+     * @return {boolean}
      */
     isTypeScriptScope() {
       return this.filename.split('.').pop() === 'ts';
@@ -218,6 +226,7 @@ export default {
      * add opening comment chars to prevent breaking of highlighting.
      *
      * @param {string} code
+     * @return {string}
      */
     fixUnclosedComment(code) {
       const lines = code.split('\n').map(line => line.trim());
@@ -247,11 +256,13 @@ export default {
     font-family: var(--font-monospace);
     background-color: var(--color-bg-code-fragment);
     border-radius: var(--border-radius);
+    position: relative;
 
     &__content {
       flex-grow: 2;
       font-size: 12px;
       line-height: 21px;
+      z-index: 2;
     }
 
     &__lines {
@@ -260,19 +271,38 @@ export default {
       width: 35px;
 
       span {
-        display: flex;
         flex-grow: 1;
+        display: flex;
+        line-height: 21px;
         align-items: center;
         padding: 0 10px;
         color: var(--color-text-main);
         font-size: 10px;
-        line-height: 21px;
         vertical-align: bottom;
         opacity: 0.4;
 
         &::before {
           content: attr(data-line)
         }
+      }
+    }
+
+    &__rows {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      display: flex;
+      flex-direction: column;
+      z-index: 1;
+
+      div {
+        flex-grow: 1;
+      }
+
+      .current {
+        background: var(--color-bg-code-fragment-line-highlighted);
       }
     }
 
@@ -294,11 +324,6 @@ export default {
     }
 
     &__line {
-      display: flex;
-      overflow: visible;
-      font-size: 12px;
-      line-height: 21px;
-
       &--current {
         background-color: var(--color-bg-code-fragment-line-highlighted);
       }

--- a/src/components/utils/CodeFragment.vue
+++ b/src/components/utils/CodeFragment.vue
@@ -14,7 +14,7 @@
       class="code-preview__content"
       :class="{[syntax]: true }"
       v-html="escapedCodeWithPointer"
-    ></pre>
+    />
   </div>
 </template>
 
@@ -100,7 +100,7 @@ export default {
      * Prepare and return html-escaped code with the column pointer for highlighted line
      * @return {string}
      */
-    escapedCodeWithPointer(){
+    escapedCodeWithPointer() {
       const code = this.fixUnclosedComment(this.code);
 
       /**
@@ -219,19 +219,19 @@ export default {
      *
      * @param {string} code
      */
-    fixUnclosedComment(code){
+    fixUnclosedComment(code) {
       const lines = code.split('\n').map(line => line.trim());
       const firstLine = lines.shift();
 
       /**
        * If code fragment starts with "* /" we need to add opening comment and the second *
        */
-      if (firstLine.substr(0, 2) === '*/'){
+      if (firstLine.substr(0, 2) === '*/') {
         code = code.replace(/\s?\*/, '/* … *');
         /**
          * Case when the fragment start with *
          */
-      } else if (firstLine.substr(0, 1) === '*'){
+      } else if (firstLine.substr(0, 1) === '*') {
         code = code.replace(/\s?\*/, '/* … ');
       }
 
@@ -260,13 +260,13 @@ export default {
       width: 35px;
 
       span {
-        flex-grow: 1;
         display: flex;
-        line-height: 21px;
+        flex-grow: 1;
         align-items: center;
         padding: 0 10px;
         color: var(--color-text-main);
         font-size: 10px;
+        line-height: 21px;
         vertical-align: bottom;
         opacity: 0.4;
 

--- a/src/components/utils/CodeFragment.vue
+++ b/src/components/utils/CodeFragment.vue
@@ -3,7 +3,7 @@
     ref="content"
     class="code-preview"
   >
-    <div class="code-preview__lines">
+    <div class="code-preview__line-numbers">
       <span
         v-for="row in lines"
         :key="row.line"
@@ -268,7 +268,7 @@ export default {
       line-height: 21px;
     }
 
-    &__lines {
+    &__line-numbers {
       display: flex;
       flex-direction: column;
       width: 35px;

--- a/src/components/utils/CodeFragment.vue
+++ b/src/components/utils/CodeFragment.vue
@@ -252,17 +252,17 @@ export default {
 
 <style>
   .code-preview {
+    position: relative;
     display: flex;
     font-family: var(--font-monospace);
     background-color: var(--color-bg-code-fragment);
     border-radius: var(--border-radius);
-    position: relative;
 
     &__content {
+      z-index: 2;
       flex-grow: 2;
       font-size: 12px;
       line-height: 21px;
-      z-index: 2;
     }
 
     &__lines {
@@ -271,13 +271,13 @@ export default {
       width: 35px;
 
       span {
-        flex-grow: 1;
         display: flex;
-        line-height: 21px;
+        flex-grow: 1;
         align-items: center;
         padding: 0 10px;
         color: var(--color-text-main);
         font-size: 10px;
+        line-height: 21px;
         vertical-align: bottom;
         opacity: 0.4;
 
@@ -293,9 +293,9 @@ export default {
       right: 0;
       bottom: 0;
       left: 0;
+      z-index: 1;
       display: flex;
       flex-direction: column;
-      z-index: 1;
 
       div {
         flex-grow: 1;

--- a/src/components/utils/CodeFragment.vue
+++ b/src/components/utils/CodeFragment.vue
@@ -325,11 +325,5 @@ export default {
         content: '';
       }
     }
-
-    &__line {
-      &--current {
-        background-color: var(--color-bg-code-fragment-line-highlighted);
-      }
-    }
   }
 </style>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -238,3 +238,31 @@ export function strReplaceAt(string: string, index: number, replacement: string)
 
   return leftPart + replacement + rightPart;
 }
+
+/**
+ * Return real offset by line number and column number of string
+ * @param {string} string - where to find
+ * @param {number} line - searching line number
+ * @param {number} column - searching column number
+ */
+export function findOffsetByLineAndCol(string: string, line: number, column: number): number {
+  let currentLine = 0;
+  let position = 0;
+  let offset = 0;
+
+  for (let i = 0, lenCached = string.length; i < lenCached; i++) {
+    if (string[i] === '\n') {
+      currentLine++;
+      position = 0;
+    } else {
+      position++;
+    }
+
+    if (currentLine === line && position === column){
+      offset = i + 1;
+      break;
+    }
+  }
+
+  return offset;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -258,7 +258,7 @@ export function findOffsetByLineAndCol(string: string, line: number, column: num
       position++;
     }
 
-    if (currentLine === line && position === column){
+    if (currentLine === line && position === column) {
       offset = i + 1;
       break;
     }


### PR DESCRIPTION
In the master code highlighting fired for every line separated (because of unclosed-comments issue)

In this branch, the unclosed-comment issue is resolved by adding opening comment chars.

So code placed in a single `pre` tag and it is highlighted as a single instance. 

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/3684889/70940632-d40dac00-205b-11ea-865b-68175fc0d1cf.png">
