### PR TITLE
Repetition tab improvements

### DIFF
--- a/src/components/event/Layout.vue
+++ b/src/components/event/Layout.vue
@@ -40,7 +40,8 @@ export default Vue.extend({
   data() {
     const projectId: string = this.$route.params.projectId;
     const eventId: string = this.$route.params.eventId;
-    const event: HawkEvent = this.$store.getters.getProjectEventById(projectId, eventId);
+    const repetitionId: string = this.$route.params.repetitionId;
+    const event: HawkEvent = this.$store.getters.getProjectEventRepetition(projectId, eventId, repetitionId);
 
     return {
       /**
@@ -93,7 +94,7 @@ export default Vue.extend({
      * If page opened directly, this.event is null, so we need to set observer from VueX
      */
     if (!this.event) {
-      this.event = this.$store.getters.getProjectEventById(this.projectId, eventId);
+      this.event = this.$store.getters.getProjectEventRepetition(this.projectId, eventId, repetitionId);
     }
 
     this.loading = false;

--- a/src/components/event/Repetitions.vue
+++ b/src/components/event/Repetitions.vue
@@ -20,7 +20,7 @@
         v-if="event"
         class="event-repetitions__since"
       >
-        {{ event.payload.timestamp | prettyFullDate }}
+        {{ originalEvent.payload.timestamp | prettyFullDate }}
         <span
           v-if="daysRepeating > 1"
           class="event-repetitions__since-days"
@@ -86,17 +86,22 @@ export default Vue.extend({
     };
   },
   computed: {
+    originalEvent(): HawkEvent {
+      return this.$store.getters.getProjectEventById(this.projectId, this.event.id);
+    },
+
     /**
      * Return concrete date
      * @return {number}
      */
     daysRepeating(): number {
-      if (!this.event) {
+      if (!this.originalEvent) {
         return 0;
       }
 
       const now = (new Date()).getTime();
-      const firstOccurrence = (new Date(this.event.payload.timestamp).getTime());
+      const eventTimestamp = this.originalEvent.payload.timestamp * 1000;
+      const firstOccurrence = (new Date(eventTimestamp).getTime());
       const differenceInDays = (now - firstOccurrence) / (1000 * 3600 * 24);
 
       return Math.round(differenceInDays);
@@ -134,11 +139,11 @@ export default Vue.extend({
   methods: {
     /**
      * Returns prettified date from timestamp
-     * @param timestamp - what tot prettify
+     * @param {number} timestamp - unixtime in seconds
      * @return {string}
      */
-    getDate(timestamp: string): string {
-      const targetDate = new Date(timestamp);
+    getDate(timestamp: number): string {
+      const targetDate = new Date(timestamp * 1000);
       const day = targetDate.getDate();
       const month = targetDate.getMonth();
 

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -125,15 +125,13 @@ Vue.filter('prettyDate', function (value: number) {
  * Returns prettified date ('29 aug, 14:30')
  * @return {string}
  */
-Vue.filter('prettyFullDate', function (value: Date | string) {
-  if (typeof value === 'string') {
-    value = new Date(value);
-  }
+Vue.filter('prettyFullDate', function (value: number) {
+  const date = new Date(value * 1000);
 
-  const day = value.getDate();
-  const month = value.getMonth();
-  const hours = value.getHours();
-  const minutes = value.getMinutes();
+  const day = date.getDate();
+  const month = date.getMonth();
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
 
   return `${day} ${i18n.t(`common.shortMonths[${month}]`)}, ${`0${hours}`.substr(-2)}:${`0${minutes}`.substr(-2)}`;
 });

--- a/src/store/modules/events/index.ts
+++ b/src/store/modules/events/index.ts
@@ -196,6 +196,36 @@ const module: Module<EventsModuleState, RootState> = {
         return state.list[key] || null;
       };
     },
+    /**
+     * Returns merged original event with passed repetition from stores
+     */
+    getProjectEventRepetition(state) {
+      /**
+       * @param {string} projectId - event's project id
+       * @param {string} eventId - event id
+       */
+      return (projectId: string, eventId: string, repetitionId: string): HawkEvent | null => {
+        const key = getEventsListKey(projectId, eventId);
+
+        if (!state.repetitions[key]) {
+          return state.list[key] || null;
+        }
+
+        let repetition;
+        if (!repetitionId) {
+          repetition = state.repetitions[key][state.repetitions[key].length - 1];
+        } else {
+          repetition = state.repetitions[key].find( repetition => {
+            return repetition.id === repetitionId
+          });
+        }
+
+        const event = Object.assign({}, state.list[key]);
+        event.payload = deepMerge(event.payload, repetition.payload);
+
+        return event;
+      };
+    },
 
     /**
      * Returns latest recent event of the project by its id
@@ -329,6 +359,14 @@ const module: Module<EventsModuleState, RootState> = {
         return;
       }
 
+      /**
+       * Updates or sets event's fetched payload in the state
+       */
+      commit(MutationTypes.UPDATE_EVENT_PAYLOAD, {
+        projectId,
+        event,
+      });
+
       const repetition = event.repetition;
 
       if (repetition !== null) {
@@ -339,14 +377,6 @@ const module: Module<EventsModuleState, RootState> = {
           repetition,
         });
       }
-
-      /**
-       * Updates or sets event's fetched payload in the state
-       */
-      commit(MutationTypes.UPDATE_EVENT_PAYLOAD, {
-        projectId,
-        event,
-      });
     },
 
     /**

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -113,7 +113,7 @@ interface HawkEventPayload {
   /**
    * Event timestamp
    */
-  timestamp: string;
+  timestamp: number;
 
   /**
    * Event stack array from the latest call to the earliest


### PR DESCRIPTION
this PR fixes the following things:
- event repetition `since` indicator (it must be calculated from the original event)
- event repetitions `time` on each row
- event `daysRepeating` indicator (also must be calculated from the original event)