### PR TITLE
Feature: accept graphql erros

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,6 +17,55 @@ let blockingRequest: Promise<AxiosResponse>;
 let tokenRefreshingRequest: Promise<string> | null;
 
 /**
+ * Describe format of the GraphQL API error item
+ */
+interface GraphQLError {
+  /**
+   * Error text message
+   */
+  message: string;
+
+  /**
+   * Where error occurred - path to file
+   */
+  path: string[],
+  /**
+   * Where error occurred - line and col
+   */
+  location: {line: number, column: number}[];
+
+  /**
+   * Error code and stacktrace
+   */
+  extensions: {code: string, exception: {stacktrace: string[]}}
+}
+
+
+/**
+ * Print API error to the console
+ * @param error - GraphQL error
+ * @param response - Response given
+ * @param request - GraphQL request that was sent
+ * @param variables - request variables
+ */
+function printApiError(error: GraphQLError, response: {data: object}, request: string, variables?: object): void {
+  console.log('\n');
+  console.group('❌ API error ---> ' + error.message);
+    console.groupCollapsed('┕ Error details');
+      console.error(error);
+    console.groupEnd();
+    console.groupCollapsed('┕ Original request');
+      console.log(request.trim());
+      console.log('Variables', variables);
+    console.groupEnd();
+    console.groupCollapsed('┕ Data returned');
+      console.log(response ? response.data : '—');
+    console.groupEnd();
+  console.groupEnd();
+  console.log('\n');
+}
+
+/**
  * Settings that can be passed in api.call() method (see below)
  */
 interface ApiCallSettings {
@@ -92,55 +141,6 @@ export async function call(
   }
 
   return response.data.data;
-}
-
-/**
- * Describe format of the GraphQL API error item
- */
-interface GraphQLError {
-  /**
-   * Error text message
-   */
-  message: string;
-
-  /**
-   * Where error occurred - path to file
-   */
-  path: string[],
-  /**
-   * Where error occurred - line and col
-   */
-  location: {line: number, column: number}[];
-
-  /**
-   * Error code and stacktrace
-   */
-  extensions: {code: string, exception: {stacktrace: string[]}}
-}
-
-
-/**
- * Print API error to the console
- * @param error - GraphQL error
- * @param request - GraphQL request that was sent
- * @param variables - request variables
- * @param response - Response given
- */
-function printApiError(error: GraphQLError, response: {data: object}, request: string, variables?: object){
-  console.log('\n');
-  console.group('❌ API error ---> ' + error.message);
-    console.groupCollapsed('┕ Error details');
-      console.error(error);
-    console.groupEnd();
-    console.groupCollapsed('┕ Original request');
-      console.log(request.trim());
-      console.log('Variables', variables);
-    console.groupEnd();
-    console.groupCollapsed('┕ Data returned');
-      console.log(response ? response.data : '—');
-    console.groupEnd();
-  console.groupEnd();
-  console.log('\n');
 }
 
 /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -132,7 +132,7 @@ export async function call(
   }
 
   /**
-   * For now (Apr 10, 20202) all previous code await to get only data
+   * For now (Apr 10, 2020) all previous code await to get only data
    * so new request will pass allowErrors=true and get both errors and data
    * @todo refactor old requests same way
    */

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -29,6 +29,11 @@ interface ApiCallSettings {
    * If true, this request will be performed despite of initial query state
    */
   force?: boolean;
+
+  /**
+   * If true, request can return both data and errors object to handle them manually
+   */
+  allowErrors?: boolean;
 }
 
 /**
@@ -43,7 +48,7 @@ export async function call(
   request: string,
   variables?: object,
   files?: {[name: string]: File | undefined},
-  { initial = false, force = false }: ApiCallSettings = {}
+  { initial = false, force = false, allowErrors = false }: ApiCallSettings = {}
   // eslint-disable-next-line
 ): Promise<any> {
   let promise: Promise<AxiosResponse>;
@@ -72,10 +77,70 @@ export async function call(
   }
 
   if (response.data.errors) {
-    throw response.data.errors[0];
+    response.data.errors.forEach(error => {
+      printApiError(error, response.data, request, variables);
+    });
+  }
+
+  /**
+   * For now (Apr 10, 20202) all previous code await to get only data
+   * so new request will pass allowErrors=true and get both errors and data
+   * @todo refactor old requests same way
+   */
+  if (allowErrors){
+    return response.data;
   }
 
   return response.data.data;
+}
+
+/**
+ * Describe format of the GraphQL API error item
+ */
+interface GraphQLError {
+  /**
+   * Error text message
+   */
+  message: string;
+
+  /**
+   * Where error occurred - path to file
+   */
+  path: string[],
+  /**
+   * Where error occurred - line and col
+   */
+  location: {line: number, column: number}[];
+
+  /**
+   * Error code and stacktrace
+   */
+  extensions: {code: string, exception: {stacktrace: string[]}}
+}
+
+
+/**
+ * Print API error to the console
+ * @param error - GraphQL error
+ * @param request - GraphQL request that was sent
+ * @param variables - request variables
+ * @param response - Response given
+ */
+function printApiError(error: GraphQLError, response: {data: object}, request: string, variables?: object){
+  console.log('\n');
+  console.group('❌ API error ---> ' + error.message);
+    console.groupCollapsed('┕ Error details');
+      console.error(error);
+    console.groupEnd();
+    console.groupCollapsed('┕ Original request');
+      console.log(request.trim());
+      console.log('Variables', variables);
+    console.groupEnd();
+    console.groupCollapsed('┕ Data returned');
+      console.log(response ? response.data : '—');
+    console.groupEnd();
+  console.groupEnd();
+  console.log('\n');
 }
 
 /**

--- a/src/api/workspaces/index.ts
+++ b/src/api/workspaces/index.ts
@@ -39,7 +39,10 @@ export async function createWorkspace(workspaceInfo: CreateWorkspaceInput): Prom
  * @return {Promise<[Workspace]>}
  */
 export async function getAllWorkspacesWithProjects(): Promise<Workspace[]> {
-  return (await api.call(QUERY_ALL_WORKSPACES_WITH_PROJECTS, undefined, undefined, { initial: true })).workspaces;
+  return (await api.call(QUERY_ALL_WORKSPACES_WITH_PROJECTS, undefined, undefined, {
+    initial: true,
+    allowErrors: true,
+  }));
 }
 
 /**

--- a/src/api/workspaces/index.ts
+++ b/src/api/workspaces/index.ts
@@ -39,10 +39,10 @@ export async function createWorkspace(workspaceInfo: CreateWorkspaceInput): Prom
  * @return {Promise<[Workspace]>}
  */
 export async function getAllWorkspacesWithProjects(): Promise<Workspace[]> {
-  return (await api.call(QUERY_ALL_WORKSPACES_WITH_PROJECTS, undefined, undefined, {
+  return api.call(QUERY_ALL_WORKSPACES_WITH_PROJECTS, undefined, undefined, {
     initial: true,
     allowErrors: true,
-  }));
+  });
 }
 
 /**

--- a/src/store/modules/app/index.js
+++ b/src/store/modules/app/index.js
@@ -51,7 +51,26 @@ const actions = {
    * @return {Promise<void>}
    */
   async [FETCH_INITIAL_DATA]({ dispatch }) {
-    const workspaces = await workspacesApi.getAllWorkspacesWithProjects();
+    const response = await workspacesApi.getAllWorkspacesWithProjects();
+
+    /**
+     * Response can contain errors, so we should handle only existed fields
+     */
+    if (!response.data || !response.data.workspaces) {
+      console.error('FETCH_INITIAL_DATA: wrong response');
+
+      return;
+    }
+
+    const workspaces = response.data.workspaces;
+
+    dispatch(SET_WORKSPACES_LIST, workspaces);
+
+    if (!workspaces.projects) {
+      console.error('FETCH_INITIAL_DATA: projects does not returned');
+
+      return;
+    }
 
     const projects = workspaces.reduce((accumulator, workspace) => {
       if (workspace.projects) {
@@ -88,7 +107,6 @@ const actions = {
       delete project.recentEvents;
     });
 
-    dispatch(SET_WORKSPACES_LIST, workspaces);
     dispatch(SET_PROJECTS_LIST, projects);
     dispatch(INIT_EVENTS_MODULE, {
       events,

--- a/src/store/modules/app/index.js
+++ b/src/store/modules/app/index.js
@@ -66,12 +66,6 @@ const actions = {
 
     dispatch(SET_WORKSPACES_LIST, workspaces);
 
-    if (!workspaces.projects) {
-      console.error('FETCH_INITIAL_DATA: projects does not returned');
-
-      return;
-    }
-
     const projects = workspaces.reduce((accumulator, workspace) => {
       if (workspace.projects) {
         workspace.projects.forEach(project => {
@@ -83,6 +77,8 @@ const actions = {
 
       return accumulator;
     }, []);
+
+    dispatch(SET_PROJECTS_LIST, projects);
 
     /**
      * @type {Object<string, GroupedEvent>} - all fetched events
@@ -107,7 +103,6 @@ const actions = {
       delete project.recentEvents;
     });
 
-    dispatch(SET_PROJECTS_LIST, projects);
     dispatch(INIT_EVENTS_MODULE, {
       events,
       recentEvents,


### PR DESCRIPTION
Sometimes GraphqL can return both data resolved and some errors. 

<img width="865" alt="image" src="https://user-images.githubusercontent.com/3684889/79012921-2f662b80-7b70-11ea-9dd8-480a5c4fc39e.png">

For now, client will ignore returned data if there one or more errors in response. This request add an ability to pass response with error for further handling via `allowErrors` flag.

Found errors will be printed to the console:

<img width="720" alt="image" src="https://user-images.githubusercontent.com/3684889/79012829-ef06ad80-7b6f-11ea-983c-568cb4b060dd.png">
