### PR TITLE
Github Actions: cache node_modules

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,6 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
       - name: Cache node modules
         uses: actions/cache@v1
         with:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -8,9 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
+
+      - name: Cache node modules
+        uses: actions/cache@v1
+          with:
+            path: node_modules
+            key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+            restore-keys: |
+              ${{ runner.OS }}-build-${{ env.cache-name }}-
+              ${{ runner.OS }}-build-
+              ${{ runner.OS }}-
+
       - run: yarn install
+
       - run: yarn lint:js

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,11 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-
       - name: Cache node modules
         uses: actions/cache@v1
         with:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -11,13 +11,13 @@ jobs:
 
       - name: Cache node modules
         uses: actions/cache@v1
-          with:
-            path: node_modules
-            key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
-            restore-keys: |
-              ${{ runner.OS }}-build-${{ env.cache-name }}-
-              ${{ runner.OS }}-build-
-              ${{ runner.OS }}-
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ env.cache-name }}-
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
 
       - run: yarn install
 


### PR DESCRIPTION
Optimize CI speed by:
- removing extra `actions/setup-node@` action
- cache `node_modules`