### PR TITLE
[Fix] Opening workspaces

### DIFF
--- a/src/store/modules/workspaces/index.js
+++ b/src/store/modules/workspaces/index.js
@@ -119,7 +119,7 @@ const getters = {
       const workspace = getters.getWorkspaceById(workspaceId);
       const userId = rootState.user.data.id;
 
-      return workspace.team.some(member => member.user.id === userId && member.isAdmin);
+      return workspace.team.some(member => member.user && member.user.id === userId && member.isAdmin);
     },
 };
 


### PR DESCRIPTION
Adds a check for the user field in member object. If a user doesn't register after the invitation, he hasn't userId field.
![image](https://user-images.githubusercontent.com/37909603/97052147-24fa0500-1589-11eb-8018-00a10403be78.png)
Closes #327 