### PR TITLE
[Fix] Error while saving profile info, autocomplete in form fields

### DIFF
--- a/src/api/user/index.js
+++ b/src/api/user/index.js
@@ -80,10 +80,10 @@ export async function fetchCurrentUser() {
  * @returns {Promise<boolean>}
  */
 export async function updateProfile(name, email, image) {
-  return (await api.call(MUTATION_UPDATE_PROFILE, {
+  return api.call(MUTATION_UPDATE_PROFILE, {
     name,
     email,
-  }, { image })).updateProfile;
+  }, { image }, { allowErrors: true });
 }
 
 /**

--- a/src/components/account/settings/General.vue
+++ b/src/components/account/settings/General.vue
@@ -23,7 +23,7 @@
       </div>
       <FormTextFieldset
         v-model="email"
-        auto-complete="username"
+        auto-complete="email"
         class="account-settings__section"
         :label="$t('settings.account.email')"
         required

--- a/src/components/account/settings/General.vue
+++ b/src/components/account/settings/General.vue
@@ -23,10 +23,12 @@
       </div>
       <FormTextFieldset
         v-model="email"
+        auto-complete="username"
         class="account-settings__section"
         :label="$t('settings.account.email')"
         required
         placeholder="example@example.com"
+        type="email"
         @input="showSubmitButton = true"
       />
       <ChangePasswordFieldset

--- a/src/components/account/settings/General.vue
+++ b/src/components/account/settings/General.vue
@@ -155,7 +155,10 @@ export default Vue.extend({
         });
       } catch (e) {
         notifier.show({
-          message: e.message,
+          /**
+           * Removes ' symbol from error message for working with i18n translation
+           */
+          message: this.$t('settings.account.errors.' + e.message.replace(/'/g, '')) as string,
           style: 'error',
           time: 5000,
         });

--- a/src/components/account/settings/General.vue
+++ b/src/components/account/settings/General.vue
@@ -155,10 +155,7 @@ export default Vue.extend({
         });
       } catch (e) {
         notifier.show({
-          /**
-           * Removes ' symbol from error message for working with i18n translation
-           */
-          message: this.$t('settings.account.errors.' + e.message.replace(/'/g, '')) as string,
+          message: this.$t('settings.account.errors.' + e.message) as string,
           style: 'error',
           time: 5000,
         });

--- a/src/components/auth/Form.vue
+++ b/src/components/auth/Form.vue
@@ -46,6 +46,7 @@
           v-for="(field, index) in fields"
           :key="index"
           v-model="field.value"
+          :auto-complete="field.autoComplete"
           class="auth-form__section"
           required
           :name="field.name"

--- a/src/components/auth/Login.vue
+++ b/src/components/auth/Login.vue
@@ -38,7 +38,7 @@ export default {
     return {
       fields: [
         {
-          autoComplete: 'username',
+          autoComplete: 'email',
           label: this.$t('authPages.emailAddress'),
           name: 'email',
           value: '',

--- a/src/components/auth/Login.vue
+++ b/src/components/auth/Login.vue
@@ -38,6 +38,7 @@ export default {
     return {
       fields: [
         {
+          autoComplete: 'username',
           label: this.$t('authPages.emailAddress'),
           name: 'email',
           value: '',
@@ -45,6 +46,7 @@ export default {
           type: 'email',
         },
         {
+          autoComplete: 'current-password',
           label: this.$t('authPages.password'),
           name: 'password',
           value: '',

--- a/src/components/auth/RecoverPassword.vue
+++ b/src/components/auth/RecoverPassword.vue
@@ -61,7 +61,7 @@ export default class RecoverPassword extends Vue {
   created() {
     this.fields = [
       {
-        autoComplete: 'username',
+        autoComplete: 'email',
         label: this.$t('authPages.emailAddress'),
         name: 'email',
         value: '',

--- a/src/components/auth/RecoverPassword.vue
+++ b/src/components/auth/RecoverPassword.vue
@@ -35,6 +35,7 @@ export default class RecoverPassword extends Vue {
    * Fields for reset password form
    */
   private fields!: {
+      autoComplete: string,
       label: VueI18n.TranslateResult,
       name: string,
       value: string,
@@ -60,6 +61,7 @@ export default class RecoverPassword extends Vue {
   created() {
     this.fields = [
       {
+        autoComplete: 'username',
         label: this.$t('authPages.emailAddress'),
         name: 'email',
         value: '',

--- a/src/components/auth/SignUp.vue
+++ b/src/components/auth/SignUp.vue
@@ -25,7 +25,7 @@ export default {
     return {
       fields: [
         {
-          autoComplete: 'username',
+          autoComplete: 'email',
           label: this.$t('authPages.emailAddress'),
           name: 'email',
           value: '',

--- a/src/components/auth/SignUp.vue
+++ b/src/components/auth/SignUp.vue
@@ -25,6 +25,7 @@ export default {
     return {
       fields: [
         {
+          autoComplete: 'username',
           label: this.$t('authPages.emailAddress'),
           name: 'email',
           value: '',

--- a/src/components/forms/ChangePasswordFieldset.vue
+++ b/src/components/forms/ChangePasswordFieldset.vue
@@ -20,12 +20,14 @@
     </section>
     <template v-if="showInputs">
       <FormTextFieldset
+        auto-complete="current-password"
         :value="value.old"
         :label="$t('components.changePasswordFieldSet.oldPassword')"
         type="password"
         @input="oldPasswordInput"
       />
       <FormTextFieldset
+        auto-complete="new-password"
         :value="value.new"
         class="change-password-fieldset__new-password"
         :label="$t('components.changePasswordFieldSet.newPassword')"

--- a/src/components/forms/TextFieldset.vue
+++ b/src/components/forms/TextFieldset.vue
@@ -20,6 +20,7 @@
     </div>
     <input
       :id="name"
+      :autocomplete="autoComplete"
       class="input form-fieldset__input"
       :type="type || 'text'"
       :name="name"
@@ -104,6 +105,14 @@ export default {
     isInvalid: {
       type: Boolean,
       default: false,
+    },
+
+    /**
+     * Enables autocomplete in input field
+     */
+    autoComplete: {
+      type: String,
+      default: 'on',
     },
   },
 };

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -122,7 +122,10 @@
       "profileImage": "Profile picture",
       "submit": "Save",
       "title": "Account settings",
-      "profileUpdated": "Profile was updated"
+      "profileUpdated": "Profile was updated",
+      "errors": {
+        "Cannot read property updateProfile of null": "Failed to save profile settings"
+      }
     },
     "appearance": {
       "title": "Appearance"

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -124,7 +124,7 @@
       "title": "Account settings",
       "profileUpdated": "Profile was updated",
       "errors": {
-        "Cannot read property updateProfile of null": "Failed to save profile settings"
+        "Wrong email format": "Wrong email format"
       }
     },
     "appearance": {

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -122,7 +122,10 @@
       "profileImage": "Фотография",
       "submit": "Сохранить",
       "title": "Аккаунт",
-      "profileUpdated": "Профиль обновлён"
+      "profileUpdated": "Профиль обновлён",
+      "errors": {
+        "Cannot read property updateProfile of null": "Не удалось сохранить настройки профиля"
+      }
     },
     "appearance": {
       "title": "Внешний вид"

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -124,7 +124,7 @@
       "title": "Аккаунт",
       "profileUpdated": "Профиль обновлён",
       "errors": {
-        "Cannot read property updateProfile of null": "Не удалось сохранить настройки профиля"
+        "Wrong email format": "Некорректный формат почты"
       }
     },
     "appearance": {

--- a/src/store/modules/user/index.js
+++ b/src/store/modules/user/index.js
@@ -177,7 +177,17 @@ const actions = {
    * @param {User} user - user's params to update
    */
   async [UPDATE_PROFILE](context, user) {
-    return userApi.updateProfile(user.name, user.email, user.image);
+    const response = await userApi.updateProfile(user.name, user.email, user.image);
+
+    /**
+     * Response can contain errors.
+     * Throw such errors to the Vue component to display them for user
+     */
+    if (response.errors && response.errors.length) {
+      response.errors.forEach(error => {
+        throw new Error(error.message);
+      });
+    }
   },
 
   /**


### PR DESCRIPTION
Localizes message about an error while saving profile info. Adds type="email" to input field (Closes #335).
![image](https://user-images.githubusercontent.com/37909603/99274713-b2084500-283b-11eb-8752-0771bd86e18c.png)
![image](https://user-images.githubusercontent.com/37909603/99274738-ba608000-283b-11eb-8ad7-db4755380fa7.png)

Adds autocomplete attributes to form fields (see https://web.dev/sign-in-form-best-practices/#autofill).
For example, Chrome now prompts you to generate a new strong password:
![image](https://user-images.githubusercontent.com/37909603/99274791-cb10f600-283b-11eb-92a1-b0a078bb9954.png)
