### PR TITLE
[Fix] Normalizing overflow of the event title text 

### DIFF
--- a/src/components/event/EventHeader.vue
+++ b/src/components/event/EventHeader.vue
@@ -226,6 +226,8 @@ export default Vue.extend({
       margin: 10px 0 15px;
       font-size: 18px;
       line-height: 1.67;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     &__date {


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/43967788/119274352-228f8480-bc18-11eb-96f3-96b42051b9c7.png)
after
![image](https://user-images.githubusercontent.com/43967788/119274424-700bf180-bc18-11eb-95e4-9ba8ba5fd202.png)

Closes #349 