### PR TITLE
improvements(types): api response types, repetitions request updated

### DIFF
--- a/src/api/events/index.ts
+++ b/src/api/events/index.ts
@@ -20,6 +20,7 @@ import {
 import { User } from '@/types/user';
 import { EventChartItem } from '@/types/chart';
 import NotFoundError from '../../errors/404';
+import {APIResponse} from '../../types/api';
 
 /**
  * Get specific event
@@ -86,26 +87,12 @@ export async function fetchRecentEvents(
  */
 export async function getLatestRepetitions(
   projectId: string, eventId: string, limit: number
-): Promise<HawkEventRepetition[]> {
-  return (await api.callOld(QUERY_LATEST_REPETITIONS, {
+): Promise<APIResponse<{project: { event: { repetitions: HawkEventRepetition[] } } }>> {
+  return api.call(QUERY_LATEST_REPETITIONS, {
     projectId,
     eventId,
     limit,
-  })).project.event.repetitions;
-}
-
-/**
- * Fetches event's repetition from project and returns last
- *
- * @param {string} projectId - project's identifier
- * @param {string} eventId - event's identifier
- * @returns {Promise<HawkEventRepetition | null>}
- */
-export async function getLatestRepetition(projectId: string, eventId: string): Promise<HawkEventRepetition | null> {
-  return (await api.callOld(QUERY_LATEST_REPETITIONS, {
-    projectId,
-    eventId,
-  })).project.event.repetitions.shift() || null;
+  });
 }
 
 /**

--- a/src/api/events/queries.ts
+++ b/src/api/events/queries.ts
@@ -133,6 +133,7 @@ export const QUERY_LATEST_REPETITIONS = `
         repetitions(limit: $limit) {
           id
           payload {
+            title,
             release
             timestamp
             context

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -89,44 +89,6 @@ interface ApiCallSettings {
 }
 
 /**
- * Makes request to API
- *
- * @param {string} request - request to send
- * @param {object} [variables] - request variables
- * @param {object} [files] - files to upload
- * @param {ApiCallSettings} [settings] - settings for call method
- * @returns {Promise<*>} - request data
- */
-export async function call(
-  request: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  variables?: Record<string, any>,
-  files?: {[name: string]: File | undefined},
-  { initial = false, force = false }: ApiCallSettings = {}
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<APIResponse<any>> {
-  const response = await callOld(request, variables, files, Object.assign({
-    initial,
-    force,
-  }, {
-    allowErrors: true, // forcefully set this flag. When all the requests will be refactored from api.callOld() to api.call(), remove this flag.
-  }));
-
-  /**
-   * Response can contain errors.
-   * Throw such errors to the Vue component to display them for user
-   */
-  if (response.errors && response.errors.length) {
-    response.errors.forEach(error => {
-
-      throw new Error(error.message);
-    });
-  }
-
-  return response;
-}
-
-/**
  * Makes request to API (old)
  *
  * @deprecated GraphQL can return response along with errors.
@@ -195,6 +157,44 @@ export async function callOld(
    * @deprecated old format. See method jsdoc
    */
   return response.data.data;
+}
+
+/**
+ * Makes request to API
+ *
+ * @param {string} request - request to send
+ * @param {object} [variables] - request variables
+ * @param {object} [files] - files to upload
+ * @param {ApiCallSettings} [settings] - settings for call method
+ * @returns {Promise<*>} - request data
+ */
+export async function call(
+  request: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  variables?: Record<string, any>,
+  files?: {[name: string]: File | undefined},
+  { initial = false, force = false }: ApiCallSettings = {}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<APIResponse<any>> {
+  const response = await callOld(request, variables, files, Object.assign({
+    initial,
+    force,
+  }, {
+    allowErrors: true, // forcefully set this flag. When all the requests will be refactored from api.callOld() to api.call(), remove this flag.
+  }));
+
+  /**
+   * Response can contain errors.
+   * Throw such errors to the Vue component to display them for user
+   */
+  if (response.errors && response.errors.length) {
+    response.errors.forEach(error => {
+
+      throw new Error(error.message);
+    });
+  }
+
+  return response;
 }
 
 /**

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosResponse } from 'axios';
 import { prepareFormData } from '@/api/utils';
+import { APIResponse } from '../types/api';
 
 /**
  * Hawk API endpoint URL
@@ -103,7 +104,7 @@ export async function call(
   files?: {[name: string]: File | undefined},
   { initial = false, force = false }: ApiCallSettings = {}
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<any> {
+): Promise<APIResponse<any>> {
   const response = await callOld(request, variables, files, Object.assign({
     initial,
     force,
@@ -117,6 +118,7 @@ export async function call(
    */
   if (response.errors && response.errors.length) {
     response.errors.forEach(error => {
+
       throw new Error(error.message);
     });
   }

--- a/src/api/workspaces/index.ts
+++ b/src/api/workspaces/index.ts
@@ -14,7 +14,7 @@ import {
 } from './queries';
 import * as api from '../index';
 import { Workspace } from '@/types/workspaces';
-import { APIResponseData } from '@/types/api';
+import { APIResponse, APIResponseData } from '@/types/api';
 
 interface CreateWorkspaceInput {
   /**
@@ -34,10 +34,10 @@ interface CreateWorkspaceInput {
  * @param {Workspace} workspaceInfo - workspace to create
  * @returns {Promise<Workspace>} created workspace
  */
-export async function createWorkspace(workspaceInfo: CreateWorkspaceInput): Promise<Workspace> {
+export async function createWorkspace(workspaceInfo: CreateWorkspaceInput): Promise<APIResponse<{workspace: Workspace}>> {
   const { image, ...rest } = workspaceInfo;
 
-  return api.call(MUTATION_CREATE_WORKSPACE, rest, { image });
+  return await api.call(MUTATION_CREATE_WORKSPACE, rest, {image});
 }
 
 /**
@@ -54,7 +54,7 @@ export async function leaveWorkspace(workspaceId: string): Promise<boolean> {
  *
  * @returns {Promise<Workspace[]>}
  */
-export async function getAllWorkspacesWithProjects(): Promise<Workspace[]> {
+export async function getAllWorkspacesWithProjects(): Promise<APIResponse<{ workspaces: Workspace[] }>> {
   return api.call(QUERY_ALL_WORKSPACES_WITH_PROJECTS, undefined, undefined, {
     initial: true,
   });

--- a/src/api/workspaces/index.ts
+++ b/src/api/workspaces/index.ts
@@ -14,7 +14,7 @@ import {
 } from './queries';
 import * as api from '../index';
 import { Workspace } from '@/types/workspaces';
-import { APIResponse } from '@/types/api';
+import { APIResponseData } from '@/types/api';
 
 interface CreateWorkspaceInput {
   /**
@@ -179,7 +179,7 @@ export async function removeUserFromWorkspace(
 export async function changePlanForFreePLan(
   workspaceId: string,
   planId: string
-): Promise<APIResponse<Workspace>> {
+): Promise<APIResponseData<Workspace>> {
   return (await api.callOld(MUTATION_CHANGE_WORKSPACE_PLAN_FOR_FREE_PLAN, {
     input: {
       workspaceId,

--- a/src/components/event/Repetitions.vue
+++ b/src/components/event/Repetitions.vue
@@ -90,7 +90,7 @@ export default Vue.extend({
      */
     const groupedRepetitions = new Map();
 
-    repetitions.map(repetition => {
+    repetitions.forEach(repetition => {
       const date = this.getDate(repetition.payload.timestamp);
 
       if (!groupedRepetitions.get(date)) {

--- a/src/components/event/RepetitionsList.vue
+++ b/src/components/event/RepetitionsList.vue
@@ -30,6 +30,13 @@
           </span>
         </td>
         <td class="repetitions-list__col">
+          <template
+            v-if="repetition.payload.title"
+          >
+            {{ repetition.payload.title }}
+          </template>
+        </td>
+        <td class="repetitions-list__col">
           <span
             v-if="repetition.payload.addons && repetition.payload.addons.userAgent"
             class="repetitions-list__user-browser"

--- a/src/store/modules/events/index.ts
+++ b/src/store/modules/events/index.ts
@@ -430,7 +430,8 @@ const module: Module<EventsModuleState, RootState> = {
       { commit }: { commit: Commit },
       { projectId, eventId, limit }: { projectId: string; eventId: string; limit: number }
     ): Promise<HawkEventRepetition[]> {
-      const repetitions = await eventsApi.getLatestRepetitions(projectId, eventId, limit);
+      const response = await eventsApi.getLatestRepetitions(projectId, eventId, limit);
+      const repetitions = response.data.project.event.repetitions;
 
       repetitions.map(repetition => {
         // save to the state

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -1,7 +1,13 @@
 /**
  * Common API response format
  */
-export interface APIResponse<T = unknown> {
+import { Maybe } from './utils';
+import { ASTNode } from 'vue-template-compiler';
+
+/**
+ * Proposed format of GraphQL response data
+ */
+export interface APIResponseData<T = unknown> {
   /**
    * Modified record identifier
    */
@@ -11,4 +17,42 @@ export interface APIResponse<T = unknown> {
    * Modified record
    */
   record: T;
+}
+
+/**
+ * Every GraphQL response have this structure
+ */
+export interface APIResponse<T = unknown> {
+  /**
+   * GraphQL response data
+   */
+  data: T;
+
+  /**
+   * List of GraphQL errors
+   */
+  errors: APIError[]
+}
+
+/**
+ * GraphQL error format
+ */
+export interface APIError {
+  message: string,
+  nodes?: ReadonlyArray<ASTNode> | ASTNode | undefined,
+  source?: Maybe<Source>,
+  positions?: Maybe<ReadonlyArray<number>>,
+  path?: Maybe<ReadonlyArray<string | number>>,
+  originalError?: Maybe<Error>,
+  extensions?: Maybe<{ [key: string]: any }>,
+}
+
+/**
+ * Apollo GraphQL Error source
+ */
+interface Source {
+  body: string;
+  name: string;
+  locationOffset: Location;
+  constructor(body: string, name?: string, locationOffset?: Location);
 }

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -52,8 +52,8 @@ export interface APIError {
  * Apollo GraphQL Error source
  */
 declare class Source {
-  body: string;
-  name: string;
-  locationOffset: Location;
+  public body: string;
+  public name: string;
+  public locationOffset: Location;
   constructor(body: string, name?: string, locationOffset?: Location);
 }

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -44,13 +44,14 @@ export interface APIError {
   positions?: Maybe<ReadonlyArray<number>>,
   path?: Maybe<ReadonlyArray<string | number>>,
   originalError?: Maybe<Error>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   extensions?: Maybe<{ [key: string]: any }>,
 }
 
 /**
  * Apollo GraphQL Error source
  */
-interface Source {
+declare class Source {
   body: string;
   name: string;
   locationOffset: Location;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -15,3 +15,8 @@ export type Entries<T> = {
  * type ValueOfFoo = ValueOf<Foo>; // string | number
  */
 export type ValueOf<T> = T[keyof T];
+
+/**
+ * Conveniently represents flow's "Maybe" type https://flow.org/en/docs/types/maybe/
+ */
+export type Maybe<T> = null | undefined | T;


### PR DESCRIPTION
1. Types for API Response added
2. `getLatestRepetitions()` updated to the new `api.call()`
3. Display titles in repetitions list (handy for events grouped by the Levenshtein distance)

<img width="1355" alt="image" src="https://user-images.githubusercontent.com/3684889/130626748-c42dec24-00c2-4e98-83db-5601beadebfd.png">
