### PR TITLE
fix: Show assignees list if workspace have user not accepted invite

### DIFF
--- a/src/components/event/AssigneesList.vue
+++ b/src/components/event/AssigneesList.vue
@@ -144,7 +144,9 @@ export default {
     const users = workspace.team.reduce((accumulator, user) => {
       const userData = user.user;
 
-      accumulator.push(userData);
+      if (userData) {
+        accumulator.push(userData);
+      }
 
       return accumulator;
     }, []);


### PR DESCRIPTION
Steps to repro:
1. Invite a user to workspace by email
2. Try to open assignees list

Expected: assignees list are opened