### PR TITLE
Fix base styles loading order

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -122,8 +122,6 @@ export default Vue.extend({
 });
 </script>
 
-<style src="./styles/base.css"></style>
-
 <style>
 #app {
   display: flex;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import './styles/base.css';
 import Vue from 'vue';
 import VueCookies from 'vue-cookies';
 import ConfirmationWindow from './plugins/ConfirmationWindow';


### PR DESCRIPTION
For some reason (probably, after `vue-cli` update) base styles started loading after component styles, so some CSS overrides have occurred:

<img width="494" alt="image" src="https://user-images.githubusercontent.com/3684889/149155250-09bf899b-70a2-4ae4-bb03-81d8fc9132a5.png">

This PR fixes styles loading order: base.css will always load before any Vue styles.

<img width="428" alt="image" src="https://user-images.githubusercontent.com/3684889/149155343-9d94a364-e9f0-4a79-bc83-31aabc1ac2be.png">


