### PR TITLE
fix(repetition-assembler): value to null merge in arrays

### DIFF
--- a/cypress/integration/repetitionAssembler.test.ts
+++ b/cypress/integration/repetitionAssembler.test.ts
@@ -117,6 +117,68 @@ describe('Merging of the repetition and the original event payloads at the overv
     expect(result).to.deep.equal(assembledRepetition);
   });
 
+  it('(array of objects) should replace null in original if the repetition event has value', () => {
+    originalEvent = {
+      ...originalEvent,
+      backtrace: [
+        {
+          ...baseEvent.backtrace[0],
+          sourceCode: null
+        }
+      ],
+    };
+
+    repetitionEvent = {
+      ...repetitionEvent,
+      backtrace: [
+        {
+          ...baseEvent.backtrace[0],
+          sourceCode: [
+            {
+              content: '111',
+              line: 4
+            },
+            {
+              content: '222',
+              line: 5
+            },
+            {
+              content: '333',
+              line: 6
+            }
+          ]
+        }
+      ],
+    };
+
+    assembledRepetition = {
+      ...baseEvent,
+      backtrace: [
+        {
+          ...baseEvent.backtrace[0],
+          sourceCode: [
+            {
+              content: '111',
+              line: 4
+            },
+            {
+              content: '222',
+              line: 5
+            },
+            {
+              content: '333',
+              line: 6
+            }
+          ]
+        }
+      ],
+    };
+
+    const result = repetitionAssembler(originalEvent, repetitionEvent);
+
+    expect(result).to.deep.equal(assembledRepetition);
+  });
+
   it('should take the repetition field value instead of the original event value in the array of objects', () => {
     originalEvent = {
       ...originalEvent,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.so",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -252,7 +252,7 @@ export interface HawkEventBacktraceFrame {
   /**
    * Part of source code file near the called line
    */
-  sourceCode: BacktraceSourceCode[];
+  sourceCode: BacktraceSourceCode[] | null;
 
   /**
    * Function name extracted from current stack frame

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -182,8 +182,19 @@ export function repetitionAssembler(originalEvent: HawkEventPayload, repetition:
       return originalParam;
     }
 
-    if (typeof repetitionParam === 'object' && typeof originalEvent === 'object') {
-      return repetitionAssembler(originalParam, repetitionParam);
+  
+    if (typeof repetitionParam === 'object' && typeof originalParam === 'object') {
+      /**
+       * If original event has null but repetition has some value, we need to return repetition value
+       */
+      if (originalParam === null) {
+        return repetitionParam;
+      /**
+       * Otherwise, we need to recursively merge original and repetition values
+       */
+      } else {
+        return repetitionAssembler(originalParam, repetitionParam);
+      }
     }
 
     return repetitionParam;


### PR DESCRIPTION
A problem has been found during debugging:

If original event has no `soucreCode` in backtrace frame, but repetition has, it was merged incorrectly

<img width="813" alt="image" src="https://github.com/user-attachments/assets/06c43847-35ca-445b-8651-3dee664c2759">

Example: 

Original event:

```js
{ 
  //...
  backtrace: [
    {
       // ...
       sourceCode: null
    }
  ]
}
```

Repetition:

```js
{ 
  //...
  backtrace: [
    {
       // ...
       sourceCode: [
          {line: 1, content: 'akdkadkad'},
          {line: 2, content: 'akdkadkad'}
       ] 
    }
  ]
}
```

Now it merges as object instead of array:

```js
{ 
  //...
  backtrace: [
    {
       // ...
       sourceCode: {
          "0": {line: 1, content: 'akdkadkad'},
          "1": {line: 2, content: 'akdkadkad'}
       } 
    }
  ]
}
```

After the fix the `sourceCode` is being merged as array

## How it can be possible

Regularly, original event contains more data then repetition. But if developer sets up source-maps after original event was sent, this can happen.


