### PR TITLE
Fix (codePreview): fix aligning

### DIFF
--- a/src/components/utils/CodeFragment.vue
+++ b/src/components/utils/CodeFragment.vue
@@ -275,6 +275,10 @@ export default {
       flex-grow: 2;
       font-size: 12px;
       line-height: 21px;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
     }
 
     &__line-numbers {


### PR DESCRIPTION
## Problem
On windows there is an issue with code fragment highlighting
![image](https://github.com/user-attachments/assets/a7b62ffc-3aa7-4d29-9f08-4e1e5c2b67b0)
This issue appears only when code fragment is horizontally scrollable
To fix this issue with highlight aligning we can just remove default webkit scrollbar:

## Fix
![image](https://github.com/user-attachments/assets/da5a3f6a-d29d-4f62-9fd0-ce3ec7cbcea8)
Code fragment is still horizontally scrollable