### PR TITLE
chore: passing projectId to project() query instead of id

### DIFF
--- a/src/api/events/queries.ts
+++ b/src/api/events/queries.ts
@@ -6,7 +6,7 @@ import { USER_FRAGMENT, EVENT_BACKTRACE } from '../fragments';
  */
 export const QUERY_EVENT = `
   query Event($projectId: ID!, $eventId: ID!, $repetitionId: ID) {
-    project(id: $projectId) {
+    project(projectId: $projectId) {
       event(id: $eventId) {
         id
         catcherType
@@ -85,7 +85,7 @@ export const QUERY_RECENT_PROJECT_EVENTS = `
     $sort: EventsSortOrder,
     $filters: EventsFiltersInput
   ) {
-    project(id: $projectId) {
+    project(projectId: $projectId) {
       recentEvents(limit: 15, skip: $skip, sort: $sort, filters: $filters) {
         events {
           id
@@ -138,7 +138,7 @@ export const QUERY_LATEST_REPETITIONS = `
     $skip: Int,
     $limit: Int
   ) {
-    project(id: $projectId) {
+    project(projectId: $projectId) {
       event(id: $eventId) {
         repetitions(skip: $skip, limit: $limit) {
           id
@@ -181,7 +181,7 @@ export const QUERY_CHART_DATA = `
     $days: Int!
     $timezoneOffset: Int!
   ) {
-    project(id: $projectId) {
+    project(projectId: $projectId) {
       event(id: $eventId) {
         chartData(
           days: $days,

--- a/src/api/projects/queries.js
+++ b/src/api/projects/queries.js
@@ -139,7 +139,7 @@ export const QUERY_CHART_DATA = `
     $days: Int!
     $timezoneOffset: Int!
   ) {
-    project(id: $projectId) {
+    project(projectId: $projectId) {
       chartData(days: $days, timezoneOffset: $timezoneOffset) {
         timestamp
         count


### PR DESCRIPTION
Changed project identifier key from `id` to `projectId` in `project()` queries

related to hawk.api request: [https://github.com/codex-team/hawk.api.nodejs/pull/455](url)