### PR TITLE
fix: not display zero affected users on daily events

### DIFF
--- a/src/components/project/EventBadge.vue
+++ b/src/components/project/EventBadge.vue
@@ -6,7 +6,7 @@
     <span class="event-badge__count">
       {{ eventCount | abbreviateNumber }}
     </span>
-    <div v-if="affectedUsersCount !== null" class="event-badge__affected-users">
+    <div v-if="affectedUsersCount !== null && affectedUsersCount > 0" class="event-badge__affected-users">
       <Icon symbol="user-small" class="event-badge__affected-users-icon"/>
       {{ affectedUsersCount | abbreviateNumber }}
     </div>


### PR DESCRIPTION
Excluded case, when displays zero affected users on daily events

<img width="790" alt="image" src="https://github.com/user-attachments/assets/bcf1ce2a-83d0-4e7a-8468-cd7208f60ef6" />