### PR TITLE
fix(auth): improve handling of authentication errors when fetching current user

### DIFF
--- a/src/api/user/index.js
+++ b/src/api/user/index.js
@@ -68,7 +68,7 @@ export async function refreshTokens(refreshToken) {
  * @returns {Promise<User>}
  */
 export async function fetchCurrentUser() {
-  return (await api.callOld(QUERY_CURRENT_USER)).me;
+  return await api.call(QUERY_CURRENT_USER, {}, undefined, { allowErrors: true });
 }
 
 /**

--- a/src/api/user/index.js
+++ b/src/api/user/index.js
@@ -65,7 +65,7 @@ export async function refreshTokens(refreshToken) {
 /**
  * Get current user
  *
- * @returns {Promise<User>}
+ * @returns {Promise<APIResponse<{ me: User }>>}
  */
 export async function fetchCurrentUser() {
   return await api.call(QUERY_CURRENT_USER, {}, undefined, { allowErrors: true });

--- a/src/store/modules/user/index.js
+++ b/src/store/modules/user/index.js
@@ -135,9 +135,22 @@ const actions = {
    * @param {Function} commit - standard Vuex commit function
    */
   async [FETCH_CURRENT_USER]({ commit }) {
-    const me = await userApi.fetchCurrentUser();
+    const response = await userApi.fetchCurrentUser();
 
-    commit(mutationTypes.SET_CURRENT_USER, me);
+    if (Array.isArray(response.errors) && response.errors.length) {
+      const code = response.errors[0].extensions.code;
+
+      /**
+       * If user is not authenticated, log out
+       */
+      if (code === 'UNAUTHENTICATED') {
+        commit(RESET_STORE);
+
+        return;
+      }
+    }
+
+    commit(mutationTypes.SET_CURRENT_USER, response.data.me);
   },
 
   /**


### PR DESCRIPTION
When you open garage with outdated session, you will see an empty garage. 
Now you will be logged out.

- Update fetchCurrentUser API method to use new api.call with error handling
- Modify user store action to handle unauthenticated errors
- Reset store if user is not authenticated