### PR TITLE
fix(event): fix since field incorrect

### DIFF
--- a/src/store/modules/events/index.ts
+++ b/src/store/modules/events/index.ts
@@ -543,6 +543,11 @@ const module: Module<EventsModuleState, RootState> = {
       filterBeautifiedAddons([ event ]);
       filterBeautifiedAddons([ event.repetition ]);
 
+      const originalEventTimestamp = event.payload.timestamp;
+      const newPayload = repetition ? repetitionAssembler(event.payload, repetition.payload) as HawkEventPayload : event.payload
+
+      newPayload.timestamp = originalEventTimestamp;
+
       /**
        * Updates or sets event's fetched payload in the state
        */
@@ -550,7 +555,7 @@ const module: Module<EventsModuleState, RootState> = {
         projectId,
         event: {
           ...event,
-          payload: repetition ? repetitionAssembler(event.payload, repetition.payload) as HawkEventPayload : event.payload,
+          payload: newPayload,
         },
       });
     },


### PR DESCRIPTION
## Problem
<img width="949" alt="image" src="https://github.com/user-attachments/assets/04ab66cc-57ca-4921-a0f4-4a1964ee66bf" />
Now since day is incorrect, it displays timestamp of the last repetition
It happens because we merge payload of the original event with the payload of the repetition (and timestamp overwrites)

## Solution
In current realisation we can save timestamp field from the original event payload and make sure, that repetition payload does not overwrite the original timestamp

- Now saving original event timestamp and on repetition merge writing original timestamp to payload
<img width="991" alt="image" src="https://github.com/user-attachments/assets/318928a6-f1bf-490d-a1cd-06a28978b058" />

### Note
Probably could be solved by moving timestamp out of the payload, but it is not designed