### PR TITLE
Console output

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/src/components/event/details/customRenderers/ConsoleOutput.vue
+++ b/src/components/event/details/customRenderers/ConsoleOutput.vue
@@ -11,8 +11,8 @@
       </button>
     </div>
     <div
-      v-for="(log, index) in displayedLogs"
-      :key="index"
+      v-for="log in displayedLogs"
+      :key="log.timestamp"
       class="log-entry"
       :class="logClass(log.method)"
     >
@@ -20,9 +20,9 @@
         <span
           v-if="log.stack && log.stack.length > 0"
           class="log-arrow"
-          @click="toggleStack(index)"
+          @click="toggleStack(log.timestamp)"
         >
-          <span :class="{ rotated: expandedStack[index] }">▶</span>
+          <span :class="{ rotated: expandedStack[log.timestamp] }">▶</span>
         </span>
         <span class="log-message">
           <template v-if="log.type">
@@ -36,7 +36,7 @@
           {{ formatTimestamp(log.timestamp) }}
         </span>
       </div>
-      <div v-if="expandedStack[index]" class="log-stack">
+      <div v-if="expandedStack[log.timestamp]" class="log-stack">
         {{ formatStack(log.stack) }}
       </div>
     </div>
@@ -50,13 +50,13 @@ export default Vue.extend({
   name: "ConsoleOutput",
   props: {
     value: {
-      type: Object as PropType<Record<string, any>>,
+      type: [Object, Array] as PropType<Record<string, any> | any[]>,
       required: true,
     },
   },
   data() {
     return {
-      expandedStack: {} as Record<number, boolean>,
+      expandedStack: {} as Record<string, boolean>,
       expandedLogs: false,
     };
   },
@@ -95,8 +95,8 @@ export default Vue.extend({
     formatStack(stack: string | null | undefined): string {
       return stack?.trim() || "No stack trace available";
     },
-    toggleStack(index: number) {
-      this.$set(this.expandedStack, index, !this.expandedStack[index]);
+    toggleStack(logKey: string) {
+      this.$set(this.expandedStack, logKey, !this.expandedStack[logKey]);
     },
   },
 });
@@ -107,7 +107,6 @@ export default Vue.extend({
   padding: 10px;
   font-family: var(--font-monospace);
   font-size: 11px;
-
   --item-border-radius: 5px;
 }
 
@@ -121,6 +120,35 @@ export default Vue.extend({
   background: var(--color-bg-second);
   color: var(--color-text-main);
   border-left: 3px solid color-mod(var(--color-text-main) alpha(10%));
+
+  &.log-error {
+    background: color-mod(var(--color-indicator-critical) alpha(15%));
+    border-left-color: var(--color-indicator-critical-dark);
+  }
+
+  &.log-warn {
+    background: color-mod(var(--color-indicator-warning) alpha(15%));
+    color: var(--color-indicator-warning);
+    border-left-color: var(--color-indicator-warning);
+  }
+
+  &.log-info {
+    background: color-mod(var(--color-indicator-medium) alpha(15%));
+    color: var(--color-indicator-medium);
+    border-left-color: var(--color-indicator-medium-dark);
+  }
+
+  &.log-debug {
+    background: color-mod(var(--color-indicator-positive) alpha(15%));
+    color: var(--color-indicator-positive);
+    border-left-color: var(--color-indicator-positive);
+  }
+
+  &.log-default {
+    background: var(--color-bg-second);
+    color: var(--color-text-main);
+    border-left-color: color-mod(var(--color-text-main) alpha(10%));
+  }
 }
 
 .log-content {
@@ -138,11 +166,11 @@ export default Vue.extend({
   &:hover {
     color: var(--color-text-main);
   }
-}
 
-.log-arrow .rotated {
-  display: inline-block;
-  transform: rotate(90deg);
+  .rotated {
+    display: inline-block;
+    transform: rotate(90deg);
+  }
 }
 
 .log-message {
@@ -203,35 +231,5 @@ export default Vue.extend({
       }
     }
   }
-}
-
-/* Log colors */
-.log-error {
-  background: color-mod(var(--color-indicator-critical) alpha(15%));
-  border-left-color: var(--color-indicator-critical-dark);
-}
-
-.log-warn {
-  background: color-mod(var(--color-indicator-warning) alpha(15%));
-  color: var(--color-indicator-warning);
-  border-left-color: var(--color-indicator-warning);
-}
-
-.log-info {
-  background: color-mod(var(--color-indicator-medium) alpha(15%));
-  color: var(--color-indicator-medium);
-  border-left-color: var(--color-indicator-medium-dark);
-}
-
-.log-debug {
-  background: color-mod(var(--color-indicator-positive) alpha(15%));
-  color: var(--color-indicator-positive);
-  border-left-color: var(--color-indicator-positive);
-}
-
-.log-default {
-  background: var(--color-bg-second);
-  color: var(--color-text-main);
-  border-left-color: color-mod(var(--color-text-main) alpha(10%));
 }
 </style>

--- a/src/components/event/details/customRenderers/ConsoleOutput.vue
+++ b/src/components/event/details/customRenderers/ConsoleOutput.vue
@@ -1,17 +1,8 @@
 <template>
   <div class="console-output">
-    <div
-      v-if="logs.length > 5"
-      class="button-container"
-    >
-      <button
-        class="show-more-btn"
-        @click="expandedLogs = !expandedLogs"
-      >
-        <span
-          class="log-arrow"
-          :class="{ rotated: expandedLogs }"
-        >▲</span>
+    <div v-if="logs.length > 5" class="button-container">
+      <button class="show-more-btn" @click="expandedLogs = !expandedLogs">
+        <span class="log-arrow" :class="{ rotated: expandedLogs }">▲</span>
         {{
           expandedLogs
             ? $t("components.consoleOutput.hide_previous")
@@ -31,22 +22,16 @@
           class="log-arrow"
           @click="toggleStack(`${log.timestamp}_${index}`)"
         >
-          <span
-            :class="{ rotated: expandedStack[`${log.timestamp}_${index}`] }"
-          >▶</span>
+          <span :class="{ rotated: expandedStack[`${log.timestamp}_${index}`] }"
+            >▶</span
+          >
         </span>
-        <span
-          class="log-message"
-          v-html="formatMessage(log)"
-        />
+        <span class="log-message" v-html="formatMessage(log)" />
         <span class="log-timestamp">
           {{ formatTimestamp(log.timestamp) }}
         </span>
       </div>
-      <div
-        v-if="expandedStack[`${log.timestamp}_${index}`]"
-        class="log-stack"
-      >
+      <div v-if="expandedStack[`${log.timestamp}_${index}`]" class="log-stack">
         {{ formatStack(log.stack) }}
       </div>
     </div>
@@ -54,7 +39,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
+import Vue, { PropType } from "vue";
 
 interface ConsoleLogEvent {
   method: string;
@@ -67,7 +52,7 @@ interface ConsoleLogEvent {
 }
 
 export default Vue.extend({
-  name: 'ConsoleOutput',
+  name: "ConsoleOutput",
   props: {
     value: {
       type: [Object, Array] as PropType<Record<string, any> | any[]>,
@@ -93,53 +78,88 @@ export default Vue.extend({
     },
   },
   methods: {
+    /**
+     * Returns the CSS class name for styling console log entries based on log level
+     *
+     * @param {string} method - The console method/log level ('error', 'warn', 'info', or 'debug')
+     * @returns {string} The corresponding CSS class name for styling the log entry
+     */
     logClass(method: string): string {
       const logClasses: Record<string, string> = {
-        error: 'log-error',
-        warn: 'log-warn',
-        info: 'log-info',
-        debug: 'log-debug',
+        error: "log-error",
+        warn: "log-warn",
+        info: "log-info",
+        debug: "log-debug",
       };
 
-      return logClasses[method?.toLowerCase()] || 'log-default';
+      return logClasses[method?.toLowerCase()] || "log-default";
     },
+    /**
+     * Formats a timestamp into a human-readable time string with milliseconds
+     *
+     * @param {string} timestamp - The timestamp to format
+     * @returns {string} Formatted time string in HH:MM:SS:mmm format
+     */
     formatTimestamp(timestamp: string): string {
       const date = new Date(timestamp);
       const timeString = date.toLocaleTimeString(undefined, {
         hour12: false,
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
       });
-      const milliseconds = String(date.getMilliseconds()).padStart(3, '0');
+      const milliseconds = String(date.getMilliseconds()).padStart(3, "0");
 
       return `${timeString}:${milliseconds}`;
     },
+    /**
+     * Formats a stack trace string, providing a fallback message if no trace is available
+     *
+     * @param {string | null | undefined} stack - The stack trace to format
+     * @returns {string} Formatted stack trace or fallback message
+     */
     formatStack(stack: string | null | undefined): string {
-      return stack?.trim() || 'No stack trace available';
+      return stack?.trim() || "No stack trace available";
     },
+    /**
+     * Toggles the visibility of the stack trace for a specific log entry
+     *
+     * @param {string} logKey - The unique identifier for the log entry
+     */
     toggleStack(logKey: string) {
       this.$set(this.expandedStack, logKey, !this.expandedStack[logKey]);
     },
+    /**
+     * Sanitizes a string by replacing special HTML characters with their entities
+     *
+     * @param {string} str - The string to sanitize
+     * @returns {string} The sanitized string with HTML entities
+     */
     sanitizeHTML(str: string): string {
       // Replace special characters with their HTML entities
       return str
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;');
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
     },
+    /**
+     * Formats a console log message with proper styling and sanitization
+     *
+     * @param {ConsoleLogEvent} log - The console log event to format
+     * @returns {string} HTML-formatted and sanitized log message with applied styles
+     */
     formatMessage(log: ConsoleLogEvent): string {
       // Add log type prefix except for regular console.log
       const prefix =
-        log.method === 'log' ? '' : `${log.type || log.method.toUpperCase()} `;
+        log.method === "log" ? "" : `${log.type || log.method.toUpperCase()} `;
 
-      if (!log.message.includes('%c')) {
+      if (!log.message.includes("%c")) {
         return this.sanitizeHTML(prefix + log.message);
       }
 
-      const parts = log.message.split('%c');
+      const parts = log.message.split("%c");
       const styles = log.styles || [];
       let result = this.sanitizeHTML(prefix);
 
@@ -147,7 +167,7 @@ export default Vue.extend({
         if (index === 0) {
           result += this.sanitizeHTML(part);
         } else {
-          const style = styles[index - 1] || '';
+          const style = styles[index - 1] || "";
           const sanitizedStyle = this.sanitizeStyle(style);
 
           result += `<span style="${sanitizedStyle}">${this.sanitizeHTML(
@@ -158,43 +178,49 @@ export default Vue.extend({
 
       return result;
     },
+    /**
+     * Sanitizes CSS styles by filtering allowed properties and values
+     *
+     * @param {string} style - The CSS style string to sanitize
+     * @returns {string} Sanitized CSS style string containing only allowed properties and values
+     */
     sanitizeStyle(style: string): string {
       // List of allowed CSS properties
       const allowedProperties = [
-        'color',
-        'background-color',
-        'font-weight',
-        'font-style',
-        'text-decoration',
-        'font-size',
-        'font-family',
+        "color",
+        "background-color",
+        "font-weight",
+        "font-style",
+        "text-decoration",
+        "font-size",
+        "font-family",
       ];
 
       // List of allowed values for specific properties
       const allowedValues: Record<string, string[]> = {
-        'font-weight': [
-          'normal',
-          'bold',
-          'lighter',
-          'bolder',
-          '100',
-          '200',
-          '300',
-          '400',
-          '500',
-          '600',
-          '700',
-          '800',
-          '900',
+        "font-weight": [
+          "normal",
+          "bold",
+          "lighter",
+          "bolder",
+          "100",
+          "200",
+          "300",
+          "400",
+          "500",
+          "600",
+          "700",
+          "800",
+          "900",
         ],
-        'font-style': ['normal', 'italic', 'oblique'],
-        'text-decoration': ['none', 'underline', 'line-through', 'overline'],
+        "font-style": ["normal", "italic", "oblique"],
+        "text-decoration": ["none", "underline", "line-through", "overline"],
       };
 
       const sanitizedStyles = style
-        .split(';')
+        .split(";")
         .map((prop) => {
-          const [key, value] = prop.split(':').map((s) => s.trim());
+          const [key, value] = prop.split(":").map((s) => s.trim());
           const normalizedKey = key.toLowerCase();
 
           if (allowedProperties.includes(normalizedKey)) {
@@ -208,8 +234,8 @@ export default Vue.extend({
             } else {
               // For other properties, validate the value format
               if (
-                normalizedKey === 'color' ||
-                normalizedKey === 'background-color'
+                normalizedKey === "color" ||
+                normalizedKey === "background-color"
               ) {
                 // Validate that the value is a valid color
                 if (
@@ -219,7 +245,7 @@ export default Vue.extend({
                 ) {
                   return `${key}: ${value}`;
                 }
-              } else if (normalizedKey === 'font-size') {
+              } else if (normalizedKey === "font-size") {
                 // Validate that the value is a valid font size
                 if (/^\d+(\.\d+)?(px|em|rem|pt|%)$/.test(value)) {
                   return `${key}: ${value}`;
@@ -231,10 +257,10 @@ export default Vue.extend({
             }
           }
 
-          return '';
+          return "";
         })
         .filter(Boolean)
-        .join('; ');
+        .join("; ");
 
       return sanitizedStyles;
     },

--- a/src/components/event/details/customRenderers/ConsoleOutput.vue
+++ b/src/components/event/details/customRenderers/ConsoleOutput.vue
@@ -1,58 +1,50 @@
 <template>
-  <div class='console-output'>
+  <div class="console-output">
+    <div class="button-container" v-if="logs.length > 5">
+      <button @click="expandedLogs = !expandedLogs" class="show-more-btn">
+        <span :class="{ rotated: expandedLogs }">▶</span>
+        {{ expandedLogs ? "Скрыть предыдущие" : "Показать предыдущие" }}
+      </button>
+    </div>
     <div
-      v-for='(log, index) in logs'
-      :key='index'
-      class='log-entry'
-      :class='logClass(log.method)'
+      v-for="(log, index) in displayedLogs"
+      :key="index"
+      class="log-entry"
+      :class="logClass(log.method)"
     >
-      <div class='log-content'>
-        <!-- Stack toggle arrow (only if stack exists and is not empty) -->
-        <span v-if='log.stack && log.stack.length > 0' class='log-arrow' @click='toggleStack(index)'>
-          <span :class='{ rotated: expandedStack[index] }'>▶</span>
+      <div class="log-content">
+        <span
+          v-if="log.stack && log.stack.length > 0"
+          class="log-arrow"
+          @click="toggleStack(index)"
+        >
+          <span :class="{ rotated: expandedStack[index] }">▶</span>
         </span>
-
-        <!-- Log message -->
-        <span class='log-message'>
+        <span class="log-message">
           <template v-if="log.type">
-            <template v-if="log.type === 'log'">
-              {{ log.message }}
-            </template>
-            <template v-else>
-              {{ log.type }}: {{ log.message }}
-            </template>
+            {{ log.type !== "log" ? log.type + ": " : "" }}{{ log.message }}
           </template>
           <template v-else>
             {{ log.message }}
           </template>
         </span>
-
-        <!-- Timestamp -->
-        <span class='log-timestamp'>
+        <span class="log-timestamp">
           {{ formatTimestamp(log.timestamp) }}
         </span>
       </div>
-
-      <!-- Collapsible stack trace -->
-      <div v-if='expandedStack[index]' class='log-stack'>
+      <div v-if="expandedStack[index]" class="log-stack">
         {{ formatStack(log.stack) }}
       </div>
     </div>
   </div>
 </template>
 
-<script lang='ts'>
-import Vue, { PropType } from 'vue';
+<script lang="ts">
+import Vue, { PropType } from "vue";
 
-/**
- * Custom Renderer for Console Output
- */
 export default Vue.extend({
-  name: 'ConsoleOutput',
+  name: "ConsoleOutput",
   props: {
-    /**
-     * Console logs object
-     */
     value: {
       type: Object as PropType<Record<string, any>>,
       required: true,
@@ -61,69 +53,56 @@ export default Vue.extend({
   data() {
     return {
       expandedStack: {} as Record<number, boolean>,
+      expandedLogs: false,
     };
   },
   computed: {
-    /**
-     * Extract logs array from object
-     */
-    logs(): any[] {
+    logs() {
       return Object.values(this.value);
+    },
+    displayedLogs() {
+      if (!this.expandedLogs && this.logs.length > 5) {
+        return this.logs.slice(-5);
+      }
+      return this.logs;
     },
   },
   methods: {
-    /**
-     * Returns CSS class based on log method
-     */
     logClass(method: string): string {
       const logClasses: Record<string, string> = {
-        error: 'log-error',
-        warn: 'log-warn',
-        info: 'log-info',
-        debug: 'log-debug',
+        error: "log-error",
+        warn: "log-warn",
+        info: "log-info",
+        debug: "log-debug",
       };
-      return logClasses[method?.toLowerCase()] || 'log-default';
+      return logClasses[method?.toLowerCase()] || "log-default";
     },
-
-    /**
-     * Formats timestamp with milliseconds
-     */
     formatTimestamp(timestamp: string): string {
       const date = new Date(timestamp);
-
-      // Форматируем основную часть времени без миллисекунд
       const timeString = date.toLocaleTimeString(undefined, {
         hour12: false,
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
       });
-
-      // Добавляем миллисекунды вручную, заменяя `,` на `:`
-      const milliseconds = String(date.getMilliseconds()).padStart(3, '0');
-
+      const milliseconds = String(date.getMilliseconds()).padStart(3, "0");
       return `${timeString}:${milliseconds}`;
     },
-
-    /**
-     * Toggle stack trace visibility
-     */
+    formatStack(stack: string | null | undefined): string {
+      return stack?.trim() || "No stack trace available";
+    },
     toggleStack(index: number) {
       this.$set(this.expandedStack, index, !this.expandedStack[index]);
     },
-
-    /**
-     * Format stack trace by removing unnecessary blank lines
-     */
-    formatStack(stack: string | null | undefined): string {
-      return stack?.trim() || 'No stack trace available';
-    },
-  }
-},);
+  },
+});
 </script>
 
 <style scoped>
-/* General log entry container */
+.console-output {
+  padding: 10px;
+}
+
 .log-entry {
   font-family: var(--font-monospace);
   padding: 2px 4px;
@@ -136,40 +115,41 @@ export default Vue.extend({
   color: var(--color-text-main);
   border-left: 3px solid color-mod(var(--color-text-main) alpha(10%));
 }
-/* Log content: arrow, message, timestamp */
+
 .log-content {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
 }
-/* Stack toggle arrow */
+
 .log-arrow {
   padding: 0 4px;
-  display: flex;
-  align-items: center;
   cursor: pointer;
   user-select: none;
   color: var(--color-text-second);
   transition: transform 0.2s ease-in-out;
-  &:hover {
-    opacity: 0.6;
-  }
 }
-.log-arrow.rotated {
+
+.log-arrow .rotated {
+  display: inline-block;
   transform: rotate(90deg);
 }
-/* Log message */
+
 .log-message {
   flex-grow: 1;
-  color: var(--color-text-main);
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
-/* Timestamp */
+
 .log-timestamp {
   color: var(--color-text-second);
   font-size: 10px;
-  margin-left: 10px;
+  min-width: 84px;
+  height: 21px;
+  display: flex;
+  align-items: center;
 }
-/* Collapsible stack trace */
+
 .log-stack {
   font-size: var(--font-small);
   margin: 2px 0;
@@ -178,27 +158,69 @@ export default Vue.extend({
   background: var(--color-bg-third);
   color: var(--color-text-main);
 }
+
+.button-container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 10px;
+
+  .show-more-btn {
+    width: 100%;
+    text-align: left;
+    padding: 6px 10px;
+    background-color: inherit;
+    border: none;
+    border-radius: var(--border-radius);
+    color: var(--color-text-main);
+    cursor: pointer;
+    font-size: 14px;
+    transition: background-color 0.3s ease;
+    display: flex;
+    align-items: center;
+
+    &:hover {
+      background-color: var(--color-bg-second);
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    span {
+      display: inline-block;
+      margin-right: 8px;
+
+      &.rotated {
+        transform: rotate(90deg);
+      }
+    }
+  }
+}
+
 /* Log colors */
 .log-error {
   background: color-mod(var(--color-indicator-critical) alpha(15%));
-  color: var(--color-indicator-critical);
   border-left-color: var(--color-indicator-critical-dark);
 }
+
 .log-warn {
   background: color-mod(var(--color-indicator-warning) alpha(15%));
   color: var(--color-indicator-warning);
   border-left-color: var(--color-indicator-warning);
 }
+
 .log-info {
   background: color-mod(var(--color-indicator-medium) alpha(15%));
   color: var(--color-indicator-medium);
   border-left-color: var(--color-indicator-medium-dark);
 }
+
 .log-debug {
   background: color-mod(var(--color-indicator-positive) alpha(15%));
   color: var(--color-indicator-positive);
   border-left-color: var(--color-indicator-positive);
 }
+
 .log-default {
   background: var(--color-bg-second);
   color: var(--color-text-main);

--- a/src/components/event/details/customRenderers/ConsoleOutput.vue
+++ b/src/components/event/details/customRenderers/ConsoleOutput.vue
@@ -1,8 +1,17 @@
 <template>
   <div class="console-output">
-    <div class="button-container" v-if="logs.length > 5">
-      <button @click="expandedLogs = !expandedLogs" class="show-more-btn">
-        <span class="log-arrow" :class="{ rotated: expandedLogs }">▲</span>
+    <div
+      v-if="logs.length > 5"
+      class="button-container"
+    >
+      <button
+        class="show-more-btn"
+        @click="expandedLogs = !expandedLogs"
+      >
+        <span
+          class="log-arrow"
+          :class="{ rotated: expandedLogs }"
+        >▲</span>
         {{
           expandedLogs
             ? $t("components.consoleOutput.hide_previous")
@@ -22,16 +31,22 @@
           class="log-arrow"
           @click="toggleStack(`${log.timestamp}_${index}`)"
         >
-          <span :class="{ rotated: expandedStack[`${log.timestamp}_${index}`] }"
-            >▶</span
-          >
+          <span
+            :class="{ rotated: expandedStack[`${log.timestamp}_${index}`] }"
+          >▶</span>
         </span>
-        <span class="log-message" v-html="formatMessage(log)"></span>
+        <span
+          class="log-message"
+          v-html="formatMessage(log)"
+        />
         <span class="log-timestamp">
           {{ formatTimestamp(log.timestamp) }}
         </span>
       </div>
-      <div v-if="expandedStack[`${log.timestamp}_${index}`]" class="log-stack">
+      <div
+        v-if="expandedStack[`${log.timestamp}_${index}`]"
+        class="log-stack"
+      >
         {{ formatStack(log.stack) }}
       </div>
     </div>
@@ -39,7 +54,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from "vue";
+import Vue, { PropType } from 'vue';
 
 interface ConsoleLogEvent {
   method: string;
@@ -52,7 +67,7 @@ interface ConsoleLogEvent {
 }
 
 export default Vue.extend({
-  name: "ConsoleOutput",
+  name: 'ConsoleOutput',
   props: {
     value: {
       type: [Object, Array] as PropType<Record<string, any> | any[]>,
@@ -73,32 +88,35 @@ export default Vue.extend({
       if (!this.expandedLogs && this.logs.length > 5) {
         return this.logs.slice(-5);
       }
+
       return this.logs;
     },
   },
   methods: {
     logClass(method: string): string {
       const logClasses: Record<string, string> = {
-        error: "log-error",
-        warn: "log-warn",
-        info: "log-info",
-        debug: "log-debug",
+        error: 'log-error',
+        warn: 'log-warn',
+        info: 'log-info',
+        debug: 'log-debug',
       };
-      return logClasses[method?.toLowerCase()] || "log-default";
+
+      return logClasses[method?.toLowerCase()] || 'log-default';
     },
     formatTimestamp(timestamp: string): string {
       const date = new Date(timestamp);
       const timeString = date.toLocaleTimeString(undefined, {
         hour12: false,
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
       });
-      const milliseconds = String(date.getMilliseconds()).padStart(3, "0");
+      const milliseconds = String(date.getMilliseconds()).padStart(3, '0');
+
       return `${timeString}:${milliseconds}`;
     },
     formatStack(stack: string | null | undefined): string {
-      return stack?.trim() || "No stack trace available";
+      return stack?.trim() || 'No stack trace available';
     },
     toggleStack(logKey: string) {
       this.$set(this.expandedStack, logKey, !this.expandedStack[logKey]);
@@ -106,27 +124,32 @@ export default Vue.extend({
     sanitizeHTML(str: string): string {
       // Replace special characters with their HTML entities
       return str
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;");
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
     },
     formatMessage(log: ConsoleLogEvent): string {
-      if (!log.message.includes("%c")) {
-        return this.sanitizeHTML(log.message);
+      // Add log type prefix except for regular console.log
+      const prefix =
+        log.method === 'log' ? '' : `${log.type || log.method.toUpperCase()} `;
+
+      if (!log.message.includes('%c')) {
+        return this.sanitizeHTML(prefix + log.message);
       }
 
-      const parts = log.message.split("%c");
+      const parts = log.message.split('%c');
       const styles = log.styles || [];
-      let result = "";
+      let result = this.sanitizeHTML(prefix);
 
       parts.forEach((part, index) => {
         if (index === 0) {
           result += this.sanitizeHTML(part);
         } else {
-          const style = styles[index - 1] || "";
+          const style = styles[index - 1] || '';
           const sanitizedStyle = this.sanitizeStyle(style);
+
           result += `<span style="${sanitizedStyle}">${this.sanitizeHTML(
             part
           )}</span>`;
@@ -138,54 +161,55 @@ export default Vue.extend({
     sanitizeStyle(style: string): string {
       // List of allowed CSS properties
       const allowedProperties = [
-        "color",
-        "background-color",
-        "font-weight",
-        "font-style",
-        "text-decoration",
-        "font-size",
-        "font-family",
+        'color',
+        'background-color',
+        'font-weight',
+        'font-style',
+        'text-decoration',
+        'font-size',
+        'font-family',
       ];
 
       // List of allowed values for specific properties
       const allowedValues: Record<string, string[]> = {
-        "font-weight": [
-          "normal",
-          "bold",
-          "lighter",
-          "bolder",
-          "100",
-          "200",
-          "300",
-          "400",
-          "500",
-          "600",
-          "700",
-          "800",
-          "900",
+        'font-weight': [
+          'normal',
+          'bold',
+          'lighter',
+          'bolder',
+          '100',
+          '200',
+          '300',
+          '400',
+          '500',
+          '600',
+          '700',
+          '800',
+          '900',
         ],
-        "font-style": ["normal", "italic", "oblique"],
-        "text-decoration": ["none", "underline", "line-through", "overline"],
+        'font-style': ['normal', 'italic', 'oblique'],
+        'text-decoration': ['none', 'underline', 'line-through', 'overline'],
       };
 
       const sanitizedStyles = style
-        .split(";")
+        .split(';')
         .map((prop) => {
-          const [key, value] = prop.split(":").map((s) => s.trim());
+          const [key, value] = prop.split(':').map((s) => s.trim());
           const normalizedKey = key.toLowerCase();
 
           if (allowedProperties.includes(normalizedKey)) {
             // Check values for properties with a limited set of allowed values
             if (allowedValues[normalizedKey]) {
               const normalizedValue = value.toLowerCase();
+
               if (allowedValues[normalizedKey].includes(normalizedValue)) {
                 return `${key}: ${value}`;
               }
             } else {
               // For other properties, validate the value format
               if (
-                normalizedKey === "color" ||
-                normalizedKey === "background-color"
+                normalizedKey === 'color' ||
+                normalizedKey === 'background-color'
               ) {
                 // Validate that the value is a valid color
                 if (
@@ -195,7 +219,7 @@ export default Vue.extend({
                 ) {
                   return `${key}: ${value}`;
                 }
-              } else if (normalizedKey === "font-size") {
+              } else if (normalizedKey === 'font-size') {
                 // Validate that the value is a valid font size
                 if (/^\d+(\.\d+)?(px|em|rem|pt|%)$/.test(value)) {
                   return `${key}: ${value}`;
@@ -206,10 +230,11 @@ export default Vue.extend({
               }
             }
           }
-          return "";
+
+          return '';
         })
         .filter(Boolean)
-        .join("; ");
+        .join('; ');
 
       return sanitizedStyles;
     },
@@ -220,21 +245,21 @@ export default Vue.extend({
 <style scoped>
 .console-output {
   padding: 10px;
-  font-family: var(--font-monospace);
   font-size: 11px;
+  font-family: var(--font-monospace);
   --item-border-radius: 5px;
 }
 
 .log-entry {
-  padding: 2px 4px;
-  border-radius: var(--item-border-radius);
-  white-space: pre-wrap;
-  margin-bottom: 2px;
   display: flex;
   flex-direction: column;
-  background: var(--color-bg-second);
+  margin-bottom: 2px;
+  padding: 2px 4px;
   color: var(--color-text-main);
+  white-space: pre-wrap;
+  background: var(--color-bg-second);
   border-left: 3px solid color-mod(var(--color-text-main) alpha(10%));
+  border-radius: var(--item-border-radius);
 
   &.log-error {
     background: color-mod(var(--color-indicator-critical) alpha(15%));
@@ -242,26 +267,26 @@ export default Vue.extend({
   }
 
   &.log-warn {
-    background: color-mod(var(--color-indicator-warning) alpha(15%));
     color: var(--color-indicator-warning);
+    background: color-mod(var(--color-indicator-warning) alpha(15%));
     border-left-color: var(--color-indicator-warning);
   }
 
   &.log-info {
-    background: color-mod(var(--color-indicator-medium) alpha(15%));
     color: var(--color-indicator-medium);
+    background: color-mod(var(--color-indicator-medium) alpha(15%));
     border-left-color: var(--color-indicator-medium-dark);
   }
 
   &.log-debug {
-    background: color-mod(var(--color-indicator-positive) alpha(15%));
     color: var(--color-indicator-positive);
+    background: color-mod(var(--color-indicator-positive) alpha(15%));
     border-left-color: var(--color-indicator-positive);
   }
 
   &.log-default {
-    background: var(--color-bg-second);
     color: var(--color-text-main);
+    background: var(--color-bg-second);
     border-left-color: color-mod(var(--color-text-main) alpha(10%));
   }
 }
@@ -274,9 +299,9 @@ export default Vue.extend({
 
 .log-arrow {
   padding: 0 4px;
-  user-select: none;
   color: var(--color-text-second);
   transition: transform 0.2s ease-in-out;
+  user-select: none;
 
   &:hover {
     color: var(--color-text-main);
@@ -296,38 +321,38 @@ export default Vue.extend({
 }
 
 .log-timestamp {
-  color: var(--color-text-second);
-  min-width: 93px;
-  height: 21px;
   display: flex;
   align-items: center;
+  min-width: 93px;
+  height: 21px;
+  color: var(--color-text-second);
 }
 
 .log-stack {
   margin: 2px 0;
   padding: 3px 8px;
-  border-radius: var(--item-border-radius);
-  background: var(--color-bg-third);
   color: var(--color-text-main);
+  background: var(--color-bg-third);
+  border-radius: var(--item-border-radius);
 }
 
 .button-container {
-  height: 25px;
   display: flex;
   justify-content: center;
+  height: 25px;
   margin-bottom: 2px;
 
   .show-more-btn {
+    display: flex;
+    align-items: center;
     width: 100%;
+    color: var(--color-text-second);
     text-align: left;
     background-color: inherit;
     border: none;
     border-radius: var(--item-border-radius);
-    color: var(--color-text-second);
     cursor: pointer;
     transition: background-color 0.3s ease;
-    display: flex;
-    align-items: center;
 
     &:hover {
       background-color: var(--color-bg-second);
@@ -339,8 +364,8 @@ export default Vue.extend({
 
     span {
       display: inline-block;
-      color: var(--color-text-second);
       margin-right: 8px;
+      color: var(--color-text-second);
 
       &.rotated {
         transform: rotate(180deg);

--- a/src/components/event/details/customRenderers/ConsoleOutput.vue
+++ b/src/components/event/details/customRenderers/ConsoleOutput.vue
@@ -2,8 +2,12 @@
   <div class="console-output">
     <div class="button-container" v-if="logs.length > 5">
       <button @click="expandedLogs = !expandedLogs" class="show-more-btn">
-        <span :class="{ rotated: expandedLogs }">▶</span>
-        {{ expandedLogs ? "Скрыть предыдущие" : "Показать предыдущие" }}
+        <span class="log-arrow" :class="{ rotated: expandedLogs }">▲</span>
+        {{
+          expandedLogs
+            ? $t("components.consoleOutput.hide_previous")
+            : $t("components.consoleOutput.show_previous")
+        }}
       </button>
     </div>
     <div
@@ -101,12 +105,15 @@ export default Vue.extend({
 <style scoped>
 .console-output {
   padding: 10px;
+  font-family: var(--font-monospace);
+  font-size: 11px;
+
+  --item-border-radius: 5px;
 }
 
 .log-entry {
-  font-family: var(--font-monospace);
   padding: 2px 4px;
-  border-radius: 5px;
+  border-radius: var(--item-border-radius);
   white-space: pre-wrap;
   margin-bottom: 2px;
   display: flex;
@@ -124,10 +131,13 @@ export default Vue.extend({
 
 .log-arrow {
   padding: 0 4px;
-  cursor: pointer;
   user-select: none;
   color: var(--color-text-second);
   transition: transform 0.2s ease-in-out;
+
+  &:hover {
+    color: var(--color-text-main);
+  }
 }
 
 .log-arrow .rotated {
@@ -143,37 +153,34 @@ export default Vue.extend({
 
 .log-timestamp {
   color: var(--color-text-second);
-  font-size: 10px;
-  min-width: 84px;
+  min-width: 93px;
   height: 21px;
   display: flex;
   align-items: center;
 }
 
 .log-stack {
-  font-size: var(--font-small);
   margin: 2px 0;
   padding: 3px 8px;
-  border-radius: 4px;
+  border-radius: var(--item-border-radius);
   background: var(--color-bg-third);
   color: var(--color-text-main);
 }
 
 .button-container {
+  height: 25px;
   display: flex;
   justify-content: center;
-  margin-bottom: 10px;
+  margin-bottom: 2px;
 
   .show-more-btn {
     width: 100%;
     text-align: left;
-    padding: 6px 10px;
     background-color: inherit;
     border: none;
-    border-radius: var(--border-radius);
-    color: var(--color-text-main);
+    border-radius: var(--item-border-radius);
+    color: var(--color-text-second);
     cursor: pointer;
-    font-size: 14px;
     transition: background-color 0.3s ease;
     display: flex;
     align-items: center;
@@ -188,10 +195,11 @@ export default Vue.extend({
 
     span {
       display: inline-block;
+      color: var(--color-text-second);
       margin-right: 8px;
 
       &.rotated {
-        transform: rotate(90deg);
+        transform: rotate(180deg);
       }
     }
   }

--- a/src/components/event/details/customRenderers/ConsoleOutput.vue
+++ b/src/components/event/details/customRenderers/ConsoleOutput.vue
@@ -1,8 +1,17 @@
 <template>
   <div class="console-output">
-    <div v-if="logs.length > 5" class="button-container">
-      <button class="show-more-btn" @click="expandedLogs = !expandedLogs">
-        <span class="log-arrow" :class="{ rotated: expandedLogs }">▲</span>
+    <div
+      v-if="logs.length > 5"
+      class="button-container"
+    >
+      <button
+        class="show-more-btn"
+        @click="expandedLogs = !expandedLogs"
+      >
+        <span
+          class="log-arrow"
+          :class="{ rotated: expandedLogs }"
+        >▲</span>
         {{
           expandedLogs
             ? $t("components.consoleOutput.hide_previous")
@@ -22,16 +31,22 @@
           class="log-arrow"
           @click="toggleStack(`${log.timestamp}_${index}`)"
         >
-          <span :class="{ rotated: expandedStack[`${log.timestamp}_${index}`] }"
-            >▶</span
-          >
+          <span
+            :class="{ rotated: expandedStack[`${log.timestamp}_${index}`] }"
+          >▶</span>
         </span>
-        <span class="log-message" v-html="formatMessage(log)" />
+        <span
+          class="log-message"
+          v-html="formatMessage(log)"
+        />
         <span class="log-timestamp">
           {{ formatTimestamp(log.timestamp) }}
         </span>
       </div>
-      <div v-if="expandedStack[`${log.timestamp}_${index}`]" class="log-stack">
+      <div
+        v-if="expandedStack[`${log.timestamp}_${index}`]"
+        class="log-stack"
+      >
         {{ formatStack(log.stack) }}
       </div>
     </div>
@@ -39,7 +54,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from "vue";
+import Vue, { PropType } from 'vue';
 
 interface ConsoleLogEvent {
   method: string;
@@ -52,7 +67,7 @@ interface ConsoleLogEvent {
 }
 
 export default Vue.extend({
-  name: "ConsoleOutput",
+  name: 'ConsoleOutput',
   props: {
     value: {
       type: [Object, Array] as PropType<Record<string, any> | any[]>,
@@ -86,13 +101,13 @@ export default Vue.extend({
      */
     logClass(method: string): string {
       const logClasses: Record<string, string> = {
-        error: "log-error",
-        warn: "log-warn",
-        info: "log-info",
-        debug: "log-debug",
+        error: 'log-error',
+        warn: 'log-warn',
+        info: 'log-info',
+        debug: 'log-debug',
       };
 
-      return logClasses[method?.toLowerCase()] || "log-default";
+      return logClasses[method?.toLowerCase()] || 'log-default';
     },
     /**
      * Formats a timestamp into a human-readable time string with milliseconds
@@ -104,11 +119,11 @@ export default Vue.extend({
       const date = new Date(timestamp);
       const timeString = date.toLocaleTimeString(undefined, {
         hour12: false,
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
       });
-      const milliseconds = String(date.getMilliseconds()).padStart(3, "0");
+      const milliseconds = String(date.getMilliseconds()).padStart(3, '0');
 
       return `${timeString}:${milliseconds}`;
     },
@@ -119,7 +134,7 @@ export default Vue.extend({
      * @returns {string} Formatted stack trace or fallback message
      */
     formatStack(stack: string | null | undefined): string {
-      return stack?.trim() || "No stack trace available";
+      return stack?.trim() || 'No stack trace available';
     },
     /**
      * Toggles the visibility of the stack trace for a specific log entry
@@ -138,11 +153,11 @@ export default Vue.extend({
     sanitizeHTML(str: string): string {
       // Replace special characters with their HTML entities
       return str
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;");
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
     },
     /**
      * Formats a console log message with proper styling and sanitization
@@ -153,13 +168,13 @@ export default Vue.extend({
     formatMessage(log: ConsoleLogEvent): string {
       // Add log type prefix except for regular console.log
       const prefix =
-        log.method === "log" ? "" : `${log.type || log.method.toUpperCase()} `;
+        log.method === 'log' ? '' : `${log.type || log.method.toUpperCase()} `;
 
-      if (!log.message.includes("%c")) {
+      if (!log.message.includes('%c')) {
         return this.sanitizeHTML(prefix + log.message);
       }
 
-      const parts = log.message.split("%c");
+      const parts = log.message.split('%c');
       const styles = log.styles || [];
       let result = this.sanitizeHTML(prefix);
 
@@ -167,7 +182,7 @@ export default Vue.extend({
         if (index === 0) {
           result += this.sanitizeHTML(part);
         } else {
-          const style = styles[index - 1] || "";
+          const style = styles[index - 1] || '';
           const sanitizedStyle = this.sanitizeStyle(style);
 
           result += `<span style="${sanitizedStyle}">${this.sanitizeHTML(
@@ -187,40 +202,40 @@ export default Vue.extend({
     sanitizeStyle(style: string): string {
       // List of allowed CSS properties
       const allowedProperties = [
-        "color",
-        "background-color",
-        "font-weight",
-        "font-style",
-        "text-decoration",
-        "font-size",
-        "font-family",
+        'color',
+        'background-color',
+        'font-weight',
+        'font-style',
+        'text-decoration',
+        'font-size',
+        'font-family',
       ];
 
       // List of allowed values for specific properties
       const allowedValues: Record<string, string[]> = {
-        "font-weight": [
-          "normal",
-          "bold",
-          "lighter",
-          "bolder",
-          "100",
-          "200",
-          "300",
-          "400",
-          "500",
-          "600",
-          "700",
-          "800",
-          "900",
+        'font-weight': [
+          'normal',
+          'bold',
+          'lighter',
+          'bolder',
+          '100',
+          '200',
+          '300',
+          '400',
+          '500',
+          '600',
+          '700',
+          '800',
+          '900',
         ],
-        "font-style": ["normal", "italic", "oblique"],
-        "text-decoration": ["none", "underline", "line-through", "overline"],
+        'font-style': ['normal', 'italic', 'oblique'],
+        'text-decoration': ['none', 'underline', 'line-through', 'overline'],
       };
 
       const sanitizedStyles = style
-        .split(";")
+        .split(';')
         .map((prop) => {
-          const [key, value] = prop.split(":").map((s) => s.trim());
+          const [key, value] = prop.split(':').map((s) => s.trim());
           const normalizedKey = key.toLowerCase();
 
           if (allowedProperties.includes(normalizedKey)) {
@@ -234,8 +249,8 @@ export default Vue.extend({
             } else {
               // For other properties, validate the value format
               if (
-                normalizedKey === "color" ||
-                normalizedKey === "background-color"
+                normalizedKey === 'color' ||
+                normalizedKey === 'background-color'
               ) {
                 // Validate that the value is a valid color
                 if (
@@ -245,7 +260,7 @@ export default Vue.extend({
                 ) {
                   return `${key}: ${value}`;
                 }
-              } else if (normalizedKey === "font-size") {
+              } else if (normalizedKey === 'font-size') {
                 // Validate that the value is a valid font size
                 if (/^\d+(\.\d+)?(px|em|rem|pt|%)$/.test(value)) {
                   return `${key}: ${value}`;
@@ -257,10 +272,10 @@ export default Vue.extend({
             }
           }
 
-          return "";
+          return '';
         })
         .filter(Boolean)
-        .join("; ");
+        .join('; ');
 
       return sanitizedStyles;
     },

--- a/src/components/event/details/customRenderers/ConsoleOutput.vue
+++ b/src/components/event/details/customRenderers/ConsoleOutput.vue
@@ -252,11 +252,22 @@ export default Vue.extend({
                 normalizedKey === 'color' ||
                 normalizedKey === 'background-color'
               ) {
-                // Validate that the value is a valid color
+                // Anonymous functions to check color
+                const validHex = (v: string) =>
+                  /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(v);
+                const validRGB = (v: string) =>
+                  /^rgb\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*\)$/.test(v);
+                const validRGBA = (v: string) =>
+                  /^rgba\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*(0|1|0?\.\d+)\s*\)$/.test(
+                    v
+                  );
+                const validColorName = (v: string) => /^[a-zA-Z]+$/.test(v);
+
                 if (
-                  /^#[0-9A-Fa-f]{3,6}$|^rgb\(\d{1,3},\s*\d{1,3},\s*\d{1,3}\)$|^rgba\(\d{1,3},\s*\d{1,3},\s*\d{1,3},\s*[0-1](\.[0-9]+)?\)$|^[a-zA-Z]+$/.test(
-                    value
-                  )
+                  validHex(value) ||
+                  validRGB(value) ||
+                  validRGBA(value) ||
+                  validColorName(value)
                 ) {
                   return `${key}: ${value}`;
                 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -50,6 +50,10 @@
     "feedbackButton": {
       "message": "Leave feedback"
     },
+    "consoleOutput": {
+      "show_previous": "Show previous",
+      "hide_previous": "Hide previous"
+    },
     "catalog": {
       "step1": "Add a project",
       "step2": "Integrate a catcher",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -432,7 +432,8 @@
     "addons": {
       "url": "Адрес",
       "window": "Окно браузера",
-      "beautifiedUserAgent": "Клиент"
+      "beautifiedUserAgent": "Клиент",
+      "consoleOutput": "Лог Консоли"
     },
     "user": {
       "unknown": "Неизвестный",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -50,6 +50,10 @@
     "feedbackButton": {
       "message": "Оставить отзыв"
     },
+    "consoleOutput": {
+      "show_previous": "Показать предыдущие",
+      "hide_previous": "Скрыть предыдущие"
+    },
     "catalog": {
       "step1": "Создать проект",
       "step2": "Интегрировать Кэтчер",


### PR DESCRIPTION
- Added support for %c formatting (like in the browser console).
- Log timestamps are now aligned on the same line.
- The arrow icon is now aligned to the top for better visual consistency.
- Only the last 5 logs are shown by default; the rest can be revealed using a “Show previous” button above them.
- Fixed internationalization for the addon name.