### PR TITLE
fix(): update assignee fix

### DIFF
--- a/src/api/events/index.ts
+++ b/src/api/events/index.ts
@@ -150,7 +150,7 @@ export async function toggleEventMark(projectId: string, eventId: string, mark: 
  * Update assignee
  *
  * @param {string} projectId - project id
- * @param {string} eventId - event id
+ * @param {string} eventId - original event id
  * @param {string} assignee - user id to assign
  */
 export async function updateAssignee(projectId: string, eventId: string, assignee: string): Promise<{ success: boolean; record: User }> {

--- a/src/components/AppShell.vue
+++ b/src/components/AppShell.vue
@@ -117,6 +117,7 @@ export default {
 
           if (project.latestEvent) {
             const latestEventId = project.latestEvent.eventId;
+
             latestEvent = this.getEvent(project.id, latestEventId);
           }
 

--- a/src/components/event/AssigneesList.vue
+++ b/src/components/event/AssigneesList.vue
@@ -68,9 +68,9 @@ export default {
     },
 
     /**
-     * Current event group hash
+     * Id of the current event
      */
-    eventGroupHash: {
+    eventId: {
       type: String,
       default: '',
     },
@@ -103,7 +103,8 @@ export default {
      * @returns {string} - assignee id or empty string
      */
     currentAssigneeId() {
-      const currentEvent = this.$store.getters.getEventByProjectIdAndGroupHash(this.projectId, this.eventGroupHash);
+      const currentEvent = this.$store.getters.getProjectEventById(this.projectId, this.eventId);
+
       const assignee = currentEvent.assignee;
 
       if (assignee && assignee.id) {
@@ -111,17 +112,6 @@ export default {
       }
 
       return '';
-    },
-
-    /**
-     * Event id
-     *
-     * @returns {string}
-     */
-    eventId() {
-      const currentEvent = this.$store.getters.getEventByProjectIdAndGroupHash(this.projectId, this.eventGroupHash);
-
-      return currentEvent.id;
     },
 
     /**

--- a/src/components/project/Overview.vue
+++ b/src/components/project/Overview.vue
@@ -48,7 +48,7 @@
               :affected-users-count="dailyEventInfo.affectedUsers"
               class="project-overview__event"
               :event="getProjectEventById(project.id, dailyEventInfo.eventId)"
-              @onAssigneeIconClick="showAssignees(project.id, dailyEventInfo.groupHash, $event)"
+              @onAssigneeIconClick="showAssignees(project.id, dailyEventInfo.eventId, $event)"
               @showEventOverview="
                 showEventOverview(
                   project.id,
@@ -81,7 +81,7 @@
           v-if="isAssigneesShowed"
           v-click-outside="hideAssigneesList"
           :style="assigneesListPosition"
-          :event-group-hash="eventGroupHash"
+          :event-id="assigneesEventId"
           :project-id="projectId"
           class="project-overview__assignees-list"
           @hide="hideAssigneesList"
@@ -144,9 +144,9 @@ export default {
       isAssigneesShowed: false,
 
       /**
-       * Event group hash for assignees
+       * Id of the event which assignees are showed
        */
-      eventGroupHash: '',
+      assigneesEventId: '',
 
       /**
        * Data for a chart
@@ -379,16 +379,16 @@ export default {
      * Shows assignees list for the specific event
      *
      * @param {string} projectId - id of the current project
-     * @param {string} groupHash - group hash of the event day
+     * @param {string} assigneesEventId - id of the event which assignees should be showed
      * @param {GroupedEvent} event - event to display assignees list
      */
-    showAssignees(projectId, groupHash, event) {
+    showAssignees(projectId, assigneesEventId, event) {
       const boundingClientRect = event.target
         .closest('.event-item__assignee')
         .getBoundingClientRect();
 
       this.isAssigneesShowed = true;
-      this.eventGroupHash = groupHash;
+      this.assigneesEventId = assigneesEventId;
       this.assigneesListPosition = {
         top: `${boundingClientRect.y - 3}px`,
         left: `${boundingClientRect.x}px`,
@@ -430,6 +430,7 @@ export default {
      * @param {string} originalEventId - id of the original event
      */
     showEventOverview(projectId, eventId, originalEventId) {
+      this.assigneesEventId = eventId;
       if (this.isAssigneesShowed) {
         this.isAssigneesShowed = false;
       } else {

--- a/src/components/utils/AssigneeBar.vue
+++ b/src/components/utils/AssigneeBar.vue
@@ -32,7 +32,7 @@
       v-if="isAssigneesShowed"
       v-click-outside="hideAssigneesList"
       :project-id="projectId"
-      :event-group-hash="event.groupHash"
+      :event-id="event.id"
       triangle="top"
       class="assignee-bar__assignees-list"
       @hide="hideAssigneesList"

--- a/src/components/utils/events/subscriptionExpiry.ts
+++ b/src/components/utils/events/subscriptionExpiry.ts
@@ -15,6 +15,7 @@ export function isEventAfterSubscriptionExpiry(
 
   // Calculate subscription expiry date (lastChargeDate + 1 month)
   const subscriptionExpiry = new Date(subscriptionLastChargeDate);
+
   subscriptionExpiry.setMonth(subscriptionExpiry.getMonth() + 1);
 
   return eventDate > subscriptionExpiry;


### PR DESCRIPTION
## Changes
- Now assignees are based on event id instead of group hash
- Changed components props respectfully
- SetEventAssignee now changes all events with same passed `originalEventId` (and gets originalEventId from the params)

<img width="1014" height="247" alt="image" src="https://github.com/user-attachments/assets/f4816e68-a9cd-4e38-99af-138b6ab9e898" />
