### PR TITLE
fix(): event overview link usage

### DIFF
--- a/src/components/event/Layout.vue
+++ b/src/components/event/Layout.vue
@@ -78,9 +78,9 @@ export default Vue.extend({
      * Current viewed event
      */
     event(): HawkEvent {
-      const { repetitionId, projectId } = this.$route.params;
+      const { repetitionId, eventId, projectId } = this.$route.params;
 
-      return this.getEvent(projectId, repetitionId);
+      return this.getEvent(projectId, repetitionId ?? eventId);
     },
   },
   /**


### PR DESCRIPTION
## Problem
Event overview does not work when only eventId passed in url

example url: https://garage.hawk.so/project/5e5fb000000009d300000000d/event/689000000008a0000000005e

## Solution
If only eventId passed in url (e.g. notifier sends this format of url) we fetch repetition by eventId (not repetitionId)
🎉🎉🎉 voila it works