### PR TITLE
fix(): fix event layout created

### DIFF
--- a/src/components/event/Layout.vue
+++ b/src/components/event/Layout.vue
@@ -94,7 +94,7 @@ export default Vue.extend({
 
     await this.$store.dispatch(FETCH_EVENT, {
       projectId: this.projectId,
-      eventId: repetitionId,
+      eventId: repetitionId ?? eventId,
       originalEventId: eventId,
     });
 


### PR DESCRIPTION
## Problem
Event overview does not work when only eventId passed in url

example url: https://garage.hawk.so/project/5e5fb000000009d300000000d/event/689000000008a0000000005e

## Solution
If only eventId passed in url (e.g. notifier sends this format of url) we fetch repetition by eventId (not repetitionId)
🎉🎉🎉 voila it works