### PR TITLE
feat(garage): add assignee filter to events search panel

### DIFF
--- a/src/api/events/index.ts
+++ b/src/api/events/index.ts
@@ -52,6 +52,7 @@ export async function getEvent(projectId: string, eventId: string, originalEvent
  * @param filters - filters for daily events
  * @param search - search string for daily events
  * @param release - release identifier to filter events
+ * @param assignee - user id to filter events by assignee
  */
 export async function fetchDailyEventsPortion(
   projectId: string,
@@ -59,7 +60,8 @@ export async function fetchDailyEventsPortion(
   sort = EventsSortOrder.ByDate,
   filters: EventsFilters = {},
   search = '',
-  release?: string
+  release?: string,
+  assignee?: string
 ): Promise<DailyEventsPortion> {
   const response = await api.call(QUERY_PROJECT_DAILY_EVENTS, {
     projectId,
@@ -68,6 +70,7 @@ export async function fetchDailyEventsPortion(
     filters,
     search,
     release,
+    assignee,
   }, undefined, {
     /**
      * This request calls on the app start, so we don't want to break app if something goes wrong

--- a/src/api/events/queries.ts
+++ b/src/api/events/queries.ts
@@ -24,9 +24,10 @@ export const QUERY_PROJECT_DAILY_EVENTS = `
     $filters: EventsFiltersInput
     $search: String
     $release: String
+    $assignee: ID
   ) {
     project(projectId: $projectId) {
-      dailyEventsPortion(sort: $sort, filters: $filters, search: $search, release: $release, nextCursor: $cursor) {
+      dailyEventsPortion(sort: $sort, filters: $filters, search: $search, release: $release, assignee: $assignee, nextCursor: $cursor) {
         nextCursor {
           groupingTimestampBoundary
           sortValueBoundary

--- a/src/components/forms/SearchField.vue
+++ b/src/components/forms/SearchField.vue
@@ -7,14 +7,17 @@
       class="form-search-field__search-icon"
       symbol="search"
     />
-    <input
-      ref="input"
-      class="form-search-field__input"
-      type="text"
-      :placeholder="placeholderText"
-      :value="modelValue"
-      @input="onChange"
-    >
+    <div class="form-search-field__input-wrap">
+      <input
+        ref="input"
+        class="form-search-field__input"
+        type="text"
+        :placeholder="placeholderText"
+        :value="modelValue"
+        @input="onChange"
+      >
+    </div>
+    <slot name="suffix" />
     <div
       v-show="inputValue"
       class="form-search-field__clear-icon-wrapper"
@@ -145,13 +148,20 @@ export default {
 
     }
 
+    &__input-wrap {
+      flex: 1;
+      min-width: 0;
+    }
+
     &__search-icon {
+      flex-shrink: 0;
       width: 14px;
       height: 14px;
       color: var(--color-text-second);
     }
 
     &__clear-icon-wrapper {
+      flex-shrink: 0;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/src/components/project/EventsList.vue
+++ b/src/components/project/EventsList.vue
@@ -11,6 +11,8 @@
         <UiSelect
           v-model="selectedAssigneeId"
           class="events-list__assignee-filter"
+          :class="{ 'events-list__assignee-filter--all': !selectedAssigneeId }"
+          :icon-left="selectedAssigneeId ? undefined : 'user-small'"
           :options="assigneeOptions"
           :placeholder="$t('event.viewedBy.assignee')"
         />
@@ -248,8 +250,9 @@ export default {
 
       return [
         {
-          label: this.$t('projects.filters.assigneeAll'),
           value: '',
+          icon: 'user-small',
+          label: this.$t('projects.filters.assigneeAll'),
         },
         ...options,
       ];
@@ -503,13 +506,37 @@ export default {
     }
 
     .ui-context-list {
+      /* Override scoped UiSelect: align popover to trigger right edge, width from content (grows left) */
+      right: 0 !important;
+      left: auto !important;
+      width: max-content !important;
+      min-width: 100%;
+      max-width: min(420px, calc(100vw - 24px));
+      box-sizing: border-box;
       background-color: var(--color-bg-main);
       border: 1px solid var(--color-border);
 
-      &__item:hover {
+      .ui-context-list__item {
+        max-width: 100%;
+        white-space: normal;
+        overflow-wrap: anywhere;
+      }
+
+      .ui-context-list__item:hover {
         background-color: var(--color-bg-third);
       }
     }
+  }
+
+  /* “All assignees” trigger: iconLeft + chevron only; label hidden via CSS (UiSelect unchanged) */
+  &__assignee-filter--all .ui-select__button {
+    font-size: 0;
+    line-height: 0;
+  }
+
+  &__assignee-filter--all .ui-select__button .icon {
+    width: 12px;
+    height: 12px;
   }
 }
 .search-container {

--- a/src/components/project/EventsList.vue
+++ b/src/components/project/EventsList.vue
@@ -503,6 +503,7 @@ export default {
     .ui-select__button {
       background-color: var(--color-bg-main);
       border: 1px solid var(--color-border);
+      gap: 2px;
     }
 
     .ui-context-list {

--- a/src/components/project/EventsList.vue
+++ b/src/components/project/EventsList.vue
@@ -551,5 +551,9 @@ export default {
 .search-container {
   width: 100%;
   margin-top: 16px;
+
+  &.form-search-field {
+      padding-inline-end: 7px;
+  }
 }
 </style>

--- a/src/components/project/EventsList.vue
+++ b/src/components/project/EventsList.vue
@@ -527,7 +527,6 @@ export default {
 
   &__assignee-filter {
     flex-shrink: 0;
-    /* Popover above event rows (assignee avatars stack high) */
     position: relative;
     z-index: 100;
 

--- a/src/components/project/EventsList.vue
+++ b/src/components/project/EventsList.vue
@@ -1,12 +1,20 @@
 <template>
   <div class="events-list">
-    <SearchField
-      v-model="searchQuery"
-      class="search-container"
-      skin="fancy"
-      :placeholder="searchFieldPlaceholder"
-      :is-c-m-d-k-enabled="true"
-    />
+    <div class="events-list__controls">
+      <SearchField
+        v-model="searchQuery"
+        class="search-container"
+        skin="fancy"
+        :placeholder="searchFieldPlaceholder"
+        :is-c-m-d-k-enabled="true"
+      />
+      <UiSelect
+        v-model="selectedAssigneeId"
+        class="events-list__assignee-filter"
+        :options="assigneeOptions"
+        :placeholder="$t('event.viewedBy.assignee')"
+      />
+    </div>
     <template v-if="hasItems">
       <div
         v-for="(eventsByDate, date) in groupedByDate"
@@ -76,6 +84,7 @@ import { mapGetters } from 'vuex';
 import { FETCH_PROJECT_OVERVIEW } from '../../store/modules/events/actionTypes';
 import SearchField from '../forms/SearchField';
 import EmptyState from '../utils/EmptyState.vue';
+import UiSelect from '../utils/UiSelect.vue';
 
 /**
  * Events list component grouped by days.
@@ -99,6 +108,7 @@ export default {
     AssigneesList,
     SearchField,
     EmptyState,
+    UiSelect,
   },
   props: {
     fallback: {
@@ -122,6 +132,10 @@ export default {
        * Raw (not grouped by groupingTimestamp) dailyEvents list
        */
       dailyEvents: [],
+      /**
+       * Selected assignee id for filtering events
+       */
+      selectedAssigneeId: '',
       /**
        * Indicates whether items are loading or not.
        */
@@ -212,6 +226,33 @@ export default {
     release() {
       return this.$route.params.release || this.$route.query?.release;
     },
+    /**
+     * Workspace for current project (contains team members)
+     */
+    workspace() {
+      return this.$store.getters.getWorkspaceByProjectId(this.projectId);
+    },
+    /**
+     * Assignee filter options (all + workspace users)
+     */
+    assigneeOptions() {
+      const users = (this.workspace?.team || [])
+        .map(member => member.user)
+        .filter(Boolean);
+
+      const options = users.map(user => ({
+        label: user.name || user.email,
+        value: String(user.id),
+      }));
+
+      return [
+        {
+          label: this.$t('projects.filters.assigneeAll'),
+          value: '',
+        },
+        ...options,
+      ];
+    },
     ...mapGetters(['getProjectEventById', 'getProjectSearch']),
     /**
      * Whether there are items to display
@@ -284,6 +325,7 @@ export default {
         nextCursor: this.dailyEventsNextCursor,
         search,
         release: this.release,
+        assignee: this.selectedAssigneeId || undefined,
       });
 
       this.dailyEventsNextCursor = nextCursor;
@@ -395,6 +437,9 @@ export default {
     searchQuery(newVal) {
       void this.debouncedSearch(newVal);
     },
+    selectedAssigneeId() {
+      this.reloadDailyEvents();
+    },
   },
 };
 </script>
@@ -403,6 +448,12 @@ export default {
 .events-list {
   display: flex;
   flex-direction: column;
+
+  &__controls {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
 
   &__group {
     margin-top: 25px;
@@ -447,8 +498,29 @@ export default {
     position: fixed;
     transform: translateX(-100%) translate(-15px, -5px);
   }
+
+  &__assignee-filter {
+    width: 152px;
+    margin-top: 16px;
+
+    .ui-select__button {
+      background-color: var(--color-bg-main);
+      border: 1px solid var(--color-border);
+    }
+
+    .ui-context-list {
+      background-color: var(--color-bg-main);
+      border: 1px solid var(--color-border);
+
+      &__item:hover {
+        background-color: var(--color-bg-third);
+      }
+    }
+  }
 }
 .search-container {
+  flex: 1 1 auto;
+  min-width: 0;
   margin-top: 16px;
 }
 </style>

--- a/src/components/project/EventsList.vue
+++ b/src/components/project/EventsList.vue
@@ -180,6 +180,10 @@ export default {
        * Anchor element for assignees popup positioning
        */
       assigneesAnchorEl: null,
+      /**
+       * When true, run reloadDailyEvents once the current load finishes (assignee changed mid-request)
+       */
+      pendingAssigneeReload: false,
     };
   },
   created() {
@@ -442,7 +446,19 @@ export default {
       void this.debouncedSearch(newVal);
     },
     selectedAssigneeId() {
+      if (this.isLoading) {
+        this.pendingAssigneeReload = true;
+
+        return;
+      }
+      this.pendingAssigneeReload = false;
       this.reloadDailyEvents();
+    },
+    isLoading(newVal) {
+      if (!newVal && this.pendingAssigneeReload) {
+        this.pendingAssigneeReload = false;
+        this.reloadDailyEvents();
+      }
     },
   },
 };

--- a/src/components/project/EventsList.vue
+++ b/src/components/project/EventsList.vue
@@ -480,6 +480,7 @@ export default {
 .events-list {
   display: flex;
   flex-direction: column;
+  min-height: 400px;
 
   &__group {
     margin-top: 25px;

--- a/src/components/project/EventsList.vue
+++ b/src/components/project/EventsList.vue
@@ -338,30 +338,33 @@ export default {
       }
 
       this.isLoading = true;
-      const search = this.getProjectSearch(this.projectId) || '';
 
-      const { nextCursor, dailyEventsWithEventsLinked } = await this.$store.dispatch(FETCH_PROJECT_OVERVIEW, {
-        projectId: this.projectId,
-        nextCursor: this.dailyEventsNextCursor,
-        search,
-        release: this.release,
-        assignee: this.selectedAssigneeId || undefined,
-      });
+      try {
+        const search = this.getProjectSearch(this.projectId) || '';
 
-      this.dailyEventsNextCursor = nextCursor;
-      this.noMore = this.dailyEventsNextCursor === null;
+        const { nextCursor, dailyEventsWithEventsLinked } = await this.$store.dispatch(FETCH_PROJECT_OVERVIEW, {
+          projectId: this.projectId,
+          nextCursor: this.dailyEventsNextCursor,
+          search,
+          release: this.release,
+          assignee: this.selectedAssigneeId || undefined,
+        });
 
-      if (this.noMore && dailyEventsWithEventsLinked.length === 0) {
-        this.$emit('no-events');
+        this.dailyEventsNextCursor = nextCursor;
+        this.noMore = this.dailyEventsNextCursor === null;
+
+        if (this.noMore && dailyEventsWithEventsLinked.length === 0) {
+          this.$emit('no-events');
+        }
+
+        if (overwrite) {
+          this.dailyEvents = [...dailyEventsWithEventsLinked];
+        } else {
+          this.dailyEvents.push(...dailyEventsWithEventsLinked);
+        }
+      } finally {
+        this.isLoading = false;
       }
-
-      if (overwrite) {
-        this.dailyEvents = [...dailyEventsWithEventsLinked];
-      } else {
-        this.dailyEvents.push(...dailyEventsWithEventsLinked);
-      }
-
-      this.isLoading = false;
     },
     /**
      * Reset pagination and reload list

--- a/src/components/project/EventsList.vue
+++ b/src/components/project/EventsList.vue
@@ -1,20 +1,21 @@
 <template>
   <div class="events-list">
-    <div class="events-list__controls">
-      <SearchField
-        v-model="searchQuery"
-        class="search-container"
-        skin="fancy"
-        :placeholder="searchFieldPlaceholder"
-        :is-c-m-d-k-enabled="true"
-      />
-      <UiSelect
-        v-model="selectedAssigneeId"
-        class="events-list__assignee-filter"
-        :options="assigneeOptions"
-        :placeholder="$t('event.viewedBy.assignee')"
-      />
-    </div>
+    <SearchField
+      v-model="searchQuery"
+      class="events-list__search search-container"
+      skin="fancy"
+      :placeholder="searchFieldPlaceholder"
+      :is-c-m-d-k-enabled="true"
+    >
+      <template #suffix>
+        <UiSelect
+          v-model="selectedAssigneeId"
+          class="events-list__assignee-filter"
+          :options="assigneeOptions"
+          :placeholder="$t('event.viewedBy.assignee')"
+        />
+      </template>
+    </SearchField>
     <template v-if="hasItems">
       <div
         v-for="(eventsByDate, date) in groupedByDate"
@@ -449,12 +450,6 @@ export default {
   display: flex;
   flex-direction: column;
 
-  &__controls {
-    display: flex;
-    gap: 10px;
-    align-items: center;
-  }
-
   &__group {
     margin-top: 25px;
   }
@@ -500,8 +495,7 @@ export default {
   }
 
   &__assignee-filter {
-    width: 152px;
-    margin-top: 16px;
+    flex-shrink: 0;
 
     .ui-select__button {
       background-color: var(--color-bg-main);
@@ -519,8 +513,7 @@ export default {
   }
 }
 .search-container {
-  flex: 1 1 auto;
-  min-width: 0;
+  width: 100%;
   margin-top: 16px;
 }
 </style>

--- a/src/components/project/EventsList.vue
+++ b/src/components/project/EventsList.vue
@@ -89,6 +89,10 @@ import SearchField from '../forms/SearchField';
 import EmptyState from '../utils/EmptyState.vue';
 import UiSelect from '../utils/UiSelect.vue';
 
+/** Must match api/src/models/eventsFactory.js assignee filter sentinels */
+const ASSIGNEE_FILTER_UNASSIGNED = '__filter_unassigned__';
+const ASSIGNEE_FILTER_ANY_ASSIGNEE = '__filter_any_assignee__';
+
 /**
  * Events list component grouped by days.
  *
@@ -256,7 +260,15 @@ export default {
         {
           value: '',
           icon: 'user-small',
-          label: this.$t('projects.filters.assigneeAll'),
+          label: this.$t('projects.filters.assigneeNoFilter'),
+        },
+        {
+          value: ASSIGNEE_FILTER_UNASSIGNED,
+          label: this.$t('projects.filters.assigneeUnassigned'),
+        },
+        {
+          value: ASSIGNEE_FILTER_ANY_ASSIGNEE,
+          label: this.$t('projects.filters.assigneeAny'),
         },
         ...options,
       ];
@@ -515,6 +527,9 @@ export default {
 
   &__assignee-filter {
     flex-shrink: 0;
+    /* Popover above event rows (assignee avatars stack high) */
+    position: relative;
+    z-index: 100;
 
     .ui-select__button {
       gap: 2px;
@@ -532,6 +547,7 @@ export default {
 
     .ui-context-list {
       /* Override scoped UiSelect: align popover to trigger right edge, width from content (grows left) */
+      z-index: 101;
       right: 0 !important;
       left: auto !important;
       width: max-content !important;
@@ -569,7 +585,9 @@ export default {
   margin-top: 16px;
 
   &.form-search-field {
-      padding-inline-end: 7px;
+    position: relative;
+    z-index: 100;
+    padding-inline-end: 7px;
   }
 }
 </style>

--- a/src/components/project/EventsList.vue
+++ b/src/components/project/EventsList.vue
@@ -501,9 +501,17 @@ export default {
     flex-shrink: 0;
 
     .ui-select__button {
-      background-color: var(--color-bg-main);
-      border: 1px solid var(--color-border);
       gap: 2px;
+      color: var(--color-text-second) !important;
+      font-weight: 500;
+      background-color: transparent !important;
+      border: none;
+      box-shadow: none;
+
+      &:hover {
+        color: var(--color-text-main) !important;
+        background-color: transparent !important;
+      }
     }
 
     .ui-context-list {

--- a/src/components/utils/UiContextList.vue
+++ b/src/components/utils/UiContextList.vue
@@ -2,7 +2,7 @@
   <div class="ui-context-list">
     <div
       v-for="item in items"
-      :key="item.label"
+      :key="item.rowKey != null ? String(item.rowKey) : item.label"
       class="ui-context-list__item"
       :class="{
         'ui-context-list__item--active': item.isActive,
@@ -51,6 +51,11 @@ export interface UiContextListItem {
    * Whether the item is disabled
    */
   isDisabled?: boolean;
+
+  /**
+   * Stable key for v-for (e.g. option value when labels may repeat)
+   */
+  rowKey?: string;
 }
 
 export default defineComponent({
@@ -90,9 +95,14 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   gap: var(--items-gap);
+  max-height: min(280px, 45vh);
   padding: 2px;
+  overflow-x: hidden;
+  overflow-y: auto;
   background-color: var(--color-bg-second);
   border-radius: var(--radius);
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
 
   &__item {
     display: flex;

--- a/src/components/utils/UiSelect.vue
+++ b/src/components/utils/UiSelect.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="ui-select">
+  <div
+    v-click-outside="close"
+    class="ui-select"
+  >
     <div
       class="ui-select__button"
       @click="isOpen = !isOpen"
@@ -55,10 +58,6 @@ export interface UiSelectOption {
    */
   isDisabled?: boolean;
 }
-/**
- * @todo support closing by click outside @see https://vueuse.org/core/onClickOutside/
- */
-
 export default defineComponent({
   components: {
     Icon,

--- a/src/components/utils/UiSelect.vue
+++ b/src/components/utils/UiSelect.vue
@@ -128,6 +128,7 @@ export default defineComponent({
      */
     selectOptionsToContextListItems(): UiContextListItem[] {
       return this.options.map(option => ({
+        rowKey: option.value,
         icon: option.icon,
         label: option.label,
         isActive: option.value === this.internalValue,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -131,7 +131,9 @@
         "byCount": "By count",
         "byAffectedUsers": "By affected users"
       },
-      "assigneeAll": "All assignees"
+      "assigneeNoFilter": "No filter",
+      "assigneeUnassigned": "Unassigned",
+      "assigneeAny": "Any assignee"
     },
     "placeholder": "No project selected",
     "loadMoreEvents": "Load more events",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -130,7 +130,8 @@
         "byDate": "By time",
         "byCount": "By count",
         "byAffectedUsers": "By affected users"
-      }
+      },
+      "assigneeAll": "All assignees"
     },
     "placeholder": "No project selected",
     "loadMoreEvents": "Load more events",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -130,7 +130,8 @@
         "byDate": "По времени",
         "byCount": "По количеству",
         "byAffectedUsers": "По пользователям"
-      }
+      },
+      "assigneeAll": "Все исполнители"
     },
     "placeholder": "Выберите проект",
     "loadMoreEvents": "Загрузить больше событий",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -131,7 +131,9 @@
         "byCount": "По количеству",
         "byAffectedUsers": "По пользователям"
       },
-      "assigneeAll": "Все исполнители"
+      "assigneeNoFilter": "Без фильтра",
+      "assigneeUnassigned": "Без исполнителя",
+      "assigneeAny": "Любой исполнитель"
     },
     "placeholder": "Выберите проект",
     "loadMoreEvents": "Загрузить больше событий",

--- a/src/store/modules/events/index.ts
+++ b/src/store/modules/events/index.ts
@@ -253,10 +253,11 @@ const module: Module<EventsModuleState, RootState> = {
      * @param payload.search - event searching regex string
      * @param payload.nextCursor - pointer to the first daily event of the portion to fetch
      */
-    async [FETCH_PROJECT_OVERVIEW]({ commit }, { projectId, search, nextCursor, release }: { projectId: string;
+    async [FETCH_PROJECT_OVERVIEW]({ commit }, { projectId, search, nextCursor, release, assignee }: { projectId: string;
       search: string;
       nextCursor: DailyEventsCursor | null;
-      release?: string; }):
+      release?: string;
+      assignee?: string; }):
       Promise<{ dailyEventsWithEventsLinked: DailyEventWithEventLinked[];
         nextCursor: string | null; }> {
       const eventsSortOrder = this.getters.getProjectOrder(projectId);
@@ -266,7 +267,8 @@ const module: Module<EventsModuleState, RootState> = {
         eventsSortOrder,
         this.getters.getProjectFilters(projectId),
         search,
-        release
+        release,
+        assignee
       );
 
       const dailyEvents = dailyEventsPortion.dailyEvents;

--- a/src/store/modules/events/index.ts
+++ b/src/store/modules/events/index.ts
@@ -252,6 +252,8 @@ const module: Module<EventsModuleState, RootState> = {
      * @param payload.projectId - id of the project to get overview for
      * @param payload.search - event searching regex string
      * @param payload.nextCursor - pointer to the first daily event of the portion to fetch
+     * @param payload.release - optional release label to filter by payload.release
+     * @param payload.assignee - optional user id to filter events by assignee
      */
     async [FETCH_PROJECT_OVERVIEW]({ commit }, { projectId, search, nextCursor, release, assignee }: { projectId: string;
       search: string;


### PR DESCRIPTION
## Problem
Project events list had search + mark filters, but no way to filter by assignee.

<img width="1006" height="288" alt="Снимок экрана 2026-03-23 в 23 28 57" src="https://github.com/user-attachments/assets/165fefd1-6a20-4bf7-961f-218ce91e6977" />
<img width="1010" height="210" alt="Снимок экрана 2026-03-23 в 23 29 26" src="https://github.com/user-attachments/assets/e7f2ade2-ec75-4d2b-8aac-eaec06b5ad2c" />
<img width="1033" height="344" alt="Снимок экрана 2026-03-23 в 23 29 45" src="https://github.com/user-attachments/assets/7e501b0c-2230-48fc-8da6-a3da364c4701" />


## Why
Provides a direct and fast way to find tasks/events assigned to a specific teammate, using existing server pagination/filter flow.
