### PR TITLE
fix(): add build revision to the vite plugin

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 // Current build revision id
-const buildRevision = Date.now()
+const buildRevision = Date.now().toString();
 
 // Get available icons
 const iconsAvailable = fs
@@ -44,7 +44,8 @@ const hawkToken = process.env.VITE_HAWK_TOKEN;
 
 if (hawkToken) {
   plugins.push(hawkVitePlugin({
-    token: hawkToken
+    token: hawkToken,
+    release: buildRevision,
   }));
 }
 


### PR DESCRIPTION
Vite plugin by default sends new Date() as a build revision

This is why we see this releases in "releases" tab
<img width="622" height="286" alt="image" src="https://github.com/user-attachments/assets/e46f1656-b8d7-426f-a255-330175f21e3d" />

however in garage we've defined release of each event with declaring of the `buildRevision`, which is Date.now(), so events are coming with UNIX format of the release

<img width="511" height="99" alt="image" src="https://github.com/user-attachments/assets/96230aa6-390f-4aad-8ef0-9744f003e956" />

So — passing exact buildRevision to the Vite plugin solves the issue
