### PR TITLE
fix(AssigneesList): set z-index to prevent stacking

### DIFF
--- a/src/components/event/AssigneesList.vue
+++ b/src/components/event/AssigneesList.vue
@@ -182,6 +182,7 @@ export default {
     background-color: var(--color-text-main);
     border-radius: var(--border-radius);
     box-shadow: 0 11px 13px -4px rgba(0, 0, 0, 0.5);
+    z-index: 100;
 
     &:after {
       position: absolute;

--- a/src/components/utils/AssigneeBar.vue
+++ b/src/components/utils/AssigneeBar.vue
@@ -142,7 +142,6 @@ export default defineComponent({
     position: absolute;
     top: 50px;
     right: -30px;
-    z-index: 1;
   }
 }
 </style>


### PR DESCRIPTION
Prevent AssigneesList popup stacking

Example:
<img width="936" height="451" alt="image" src="https://github.com/user-attachments/assets/7c839c9a-6df3-4878-89e1-ded04bea799f" />

