### PR TITLE
feat(events): show per-repetition occurrence count in repetitions table

### DIFF
--- a/src/api/fragments.ts
+++ b/src/api/fragments.ts
@@ -37,6 +37,7 @@ export const EVENT_FRAGMENT = `
     id
     catcherType
     totalCount
+    count
     assignee {
       id
       name

--- a/src/components/event/RepetitionsList.vue
+++ b/src/components/event/RepetitionsList.vue
@@ -27,6 +27,14 @@
           {{ formatTimeByRepetition(repetition) }}
         </td>
 
+        <!-- Count (optional, only when at least one repetition merges several occurrences) -->
+        <td
+          v-if="columns.includes('Count')"
+          class="repetitions-table__count"
+        >
+          {{ repetition.count || '—' }}
+        </td>
+
         <!-- User (optional) -->
         <td
           v-if="columns.includes('User')"
@@ -203,6 +211,7 @@ export default defineComponent({
       let releaseSpecifiedSomewhere = false;
       let userSpecifiedSomewhere = false;
       let titleSpecifiedSomewhere = false;
+      let countSpecifiedSomewhere = false;
 
       this.repetitions.forEach((repetition) => {
         if (repetition.payload.release) {
@@ -217,10 +226,14 @@ export default defineComponent({
           userSpecifiedSomewhere = true;
         }
 
-        if (titleSpecifiedSomewhere && userSpecifiedSomewhere && releaseSpecifiedSomewhere) {
-          return;
+        if (repetition.count) {
+          countSpecifiedSomewhere = true;
         }
       });
+
+      if (countSpecifiedSomewhere) {
+        cols.push('Count');
+      }
 
       if (userSpecifiedSomewhere) {
         cols.push('User');

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -77,6 +77,14 @@ export interface HawkEvent {
   totalCount: number;
 
   /**
+   * Number of real occurrences this single repetition represents. Undefined
+   * for the original event and for ordinary repetitions (both mean "single
+   * occurrence") — distinct from totalCount, which is the group's grand
+   * total across all repetitions.
+   */
+  count?: number;
+
+  /**
    * Users who visited this event
    */
   visitedBy: User[];


### PR DESCRIPTION
## Summary
- expose `count` field on Event via GraphQL fragment and `HawkEvent` type
- add optional Count column to the repetitions table, shown only when at least one repetition in the list has a count greater than one

Depends on `@hawk.so/types` publishing `RepetitionDBScheme.count` (codex-team/hawk.types#76, merged and published as 0.6.4), codex-team/hawk.workers#573, and codex-team/hawk.api.nodejs#658.