### PR TITLE
fix(EventActionsMenu): prevent conditional copy errors; display event menu for non-admin users

### DIFF
--- a/src/components/event/EventActionsMenu.vue
+++ b/src/components/event/EventActionsMenu.vue
@@ -32,6 +32,10 @@ interface Props {
    */
   eventPayload: HawkEventPayload;
   /**
+   * Is current user admin in workspace with this project
+   */
+  isAdmin: string;
+  /**
    * Callback to close popover
    */
   onClose?: () => void;
@@ -108,34 +112,37 @@ async function copyRawEventData(): Promise<void> {
       style: 'error',
       time: 5000,
     });
+    console.error(_error);
   }
 }
 
 /**
  * Actions available in event context menu
  */
-const menuItems = computed<ContextMenuItem[]>(() => {
-  return [
-    {
-      type: 'default',
-      title: i18n.global.t('event.copy') as string,
-      icon: 'Copy',
-      onActivate: () => {
-        props.onClose?.();
-        void copyRawEventData();
-      }
+const menuItems = computed<ContextMenuItem[]>(() => [
+  {
+    type: 'default',
+    title: i18n.global.t('event.copy') as string,
+    icon: 'Copy',
+    onActivate: () => {
+      props.onClose?.();
+      void copyRawEventData();
     },
-    {
-      type: 'default',
-      title: i18n.global.t('event.remove') as string,
-      icon: 'Trash',
-      onActivate: () => {
-        props.onClose?.();
-        confirmRemoveEvent();
-      },
-    },
-  ];
-});
+  },
+  ...(props.isAdmin
+    ? [
+        {
+          type: 'default' as const,
+          title: i18n.global.t('event.remove') as string,
+          icon: 'Trash',
+          onActivate: () => {
+            props.onClose?.();
+            confirmRemoveEvent();
+          },
+        },
+      ]
+    : []),
+]);
 </script>
 
 <style scoped>

--- a/src/components/event/EventActionsMenu.vue
+++ b/src/components/event/EventActionsMenu.vue
@@ -34,7 +34,7 @@ interface Props {
   /**
    * Is current user admin in workspace with this project
    */
-  isAdmin: string;
+  isAdmin: boolean;
   /**
    * Callback to close popover
    */
@@ -112,7 +112,7 @@ async function copyRawEventData(): Promise<void> {
       style: 'error',
       time: 5000,
     });
-    console.error(_error);
+    throw _error;
   }
 }
 
@@ -121,7 +121,8 @@ async function copyRawEventData(): Promise<void> {
  */
 const menuItems = computed<ContextMenuItem[]>(() => [
   {
-    type: 'default',
+    type: 'default' as const,
+    isVisible: true,
     title: i18n.global.t('event.copy') as string,
     icon: 'Copy',
     onActivate: () => {
@@ -129,20 +130,17 @@ const menuItems = computed<ContextMenuItem[]>(() => [
       void copyRawEventData();
     },
   },
-  ...(props.isAdmin
-    ? [
-        {
-          type: 'default' as const,
-          title: i18n.global.t('event.remove') as string,
-          icon: 'Trash',
-          onActivate: () => {
-            props.onClose?.();
-            confirmRemoveEvent();
-          },
-        },
-      ]
-    : []),
-]);
+  {
+    type: 'default' as const,
+    isVisible: props.isAdmin === true,
+    title: i18n.global.t('event.remove') as string,
+    icon: 'Trash',
+    onActivate: () => {
+      props.onClose?.();
+      confirmRemoveEvent();
+    },
+  },
+].filter(item => item.isVisible));
 </script>
 
 <style scoped>

--- a/src/components/event/EventHeader.vue
+++ b/src/components/event/EventHeader.vue
@@ -9,6 +9,7 @@
           {{ formattedFullDate }}
         </span>
         <CdxButton
+          v-if="!loading"
           class="event-header__button--more"
           secondary
           icon="EtcHorisontal"
@@ -348,6 +349,7 @@ export default defineComponent({
             projectId: this.projectId,
             eventId: this.$route.params.eventId,
             eventPayload: this.event.payload,
+            isAdmin: this.isAdmin,
             onClose: () => this.hidePopover(),
           },
         },

--- a/src/components/event/EventHeader.vue
+++ b/src/components/event/EventHeader.vue
@@ -9,7 +9,6 @@
           {{ formattedFullDate }}
         </span>
         <CdxButton
-          v-if="isAdmin"
           class="event-header__button--more"
           secondary
           icon="EtcHorisontal"
@@ -337,7 +336,7 @@ export default defineComponent({
      * @param event - native click mouse event
      */
     onMoreClick(event: MouseEvent) {
-      if (!this.isAdmin || this.loading || !this.event) {
+      if (this.loading || !this.event) {
         return;
       }
 

--- a/src/components/utils/events/stringifiedEventPayload.ts
+++ b/src/components/utils/events/stringifiedEventPayload.ts
@@ -75,7 +75,7 @@ function buildAddonsString(addons: EventAddons): string | null {
  * @returns Formatted backtrace string, or `null` if the backtrace is empty
  */
 function buildBacktraceString(backtrace: HawkEventBacktraceFrame[]): string | null {
-  if (!backtrace.length) {
+  if (!backtrace || !backtrace.length) {
     return null;
   }
 

--- a/src/components/utils/events/stringifiedEventPayload.ts
+++ b/src/components/utils/events/stringifiedEventPayload.ts
@@ -57,6 +57,10 @@ function buildObjectString(obj: object): string | null {
  * @returns Formatted addons string
  */
 function buildAddonsString(addons: EventAddons): string | null {
+  if (!addons) {
+    return null;
+  }
+
   const ignoredAddons = ['beautifiedUserAgent'];
   const filteredAddons = Object.fromEntries(
     Object.entries(addons).filter(([key]) => !ignoredAddons.includes(key))


### PR DESCRIPTION
## Summary

* Prevents conditional copy errors when `addons` or `backtrace` are `null` or `undefined`.
* Allows non-admin users to access the `EventActionsMenu`.
* Hide `EventActionsMenu` while event is loading.
