### PR TITLE
fix(codex-icons): remove fill: currentColor from codexui icons

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -200,6 +200,10 @@ body .cdx-notify {
 
 }
 
+body .codex-icon svg {
+  fill: none;
+}
+
 @media (--media-mobile) {
   body .cdx-notify {
     box-sizing: border-box;


### PR DESCRIPTION
## Summary
* Remove the `fill` property from CodexUi icons to preserve their intended appearance