### PR TITLE
fix: sanitize AI markdown response HTML to prevent XSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "axios": "^1.12.2",
     "codex-notifier": "^1.1.2",
     "cssnano": "^7.1.1",
+    "dompurify": "^3.4.12",
     "fast-glob": "^3.3.3",
     "highlight.js": "^11.11.1",
     "http-server": "^14.1.1",

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -84,6 +84,7 @@ export function splitStringIntoTextAndCodeSegments(source: string | undefined | 
 }
 
 import { escape } from '../utils';
+import DOMPurify from 'dompurify';
 
 /**
  * Return a function that renders a limited subset of Markdown to HTML.
@@ -119,5 +120,5 @@ export async function getMarkdownRenderer(): Promise<(text: string) => string> {
    * @param text - raw markdown text
    * @returns HTML string safe to inject with v-html
    */
-  return (text: string) => marked.parse(escape(text), { renderer }) as string;
+  return (text: string) => DOMPurify.sanitize(marked.parse(escape(text), { renderer }) as string);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -918,6 +918,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/web-bluetooth@^0.0.20":
   version "0.0.20"
   resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz#f066abfcd1cbe66267cdbbf0de010d8a41b41597"
@@ -1958,6 +1963,13 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
+
+dompurify@^3.4.12:
+  version "3.4.12"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.12.tgz#6fa2265e9bbdce882c4ace4107626051b448ffa8"
+  integrity sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^1.5.1:
   version "1.7.0"


### PR DESCRIPTION
- `getMarkdownRenderer()` rendered AI-generated markdown to HTML without checking link/image protocols, allowing a `javascript:` URI to survive as a real, clickable `<a href="javascript:...">` — confirmed exploitable via a real browser click (session cookie/localStorage theft).
- Output is now sanitized with [DOMPurify](https://github.com/cure53/DOMPurify) (default config) before being passed to `v-html`, matching the recommendation from `marked`'s own docs, OWASP, and Vue's security guide for this exact scenario.