### PR TITLE
fix(ci): check lint instead of fixing it

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -29,4 +29,4 @@ jobs:
 
       - run: yarn install
 
-      - run: yarn lint:js
+      - run: yarn lint-test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "yarn lint:js && yarn lint:css",
     "lint:css": "stylelint \"src/**/*{.css,.vue}\" --fix",
     "lint:js": "eslint src/ --fix",
-    "lint:errors": "eslint src/ --ext .js --ext .ts --ext .vue --quiet",
+    "lint-test": "eslint src/ --ext .js --ext .ts --ext .vue --quiet",
     "serve:prod": "http-server ./dist --push-state -c-0",
     "storybook": "vue-cli-service storybook:serve -p 6006 -c config/storybook -s ./public",
     "storybook:build": "vue-cli-service storybook:build -c config/storybook",


### PR DESCRIPTION
The lint job runs `yarn lint:js`, which is `eslint src/ --fix`. It rewrites the checkout, throws the result away and reports success unless something is unfixable, so a pull request can carry any fixable violation.

`lint:errors` already did the check and was referenced nowhere. It takes the name hawk.api.nodejs uses for the same script, `lint-test`.
