### PR TITLE
fix(markdown): drop the static parser call

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Unit tests
+
+on: [pull_request]
+
+jobs:
+  test:
+    name: Vitest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Enable corepack for yarn version management
+        run: corepack enable
+
+      - run: yarn install
+
+      - run: yarn test

--- a/src/utils/markdown.test.ts
+++ b/src/utils/markdown.test.ts
@@ -1,0 +1,100 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getMarkdownRenderer, splitStringIntoTextAndCodeSegments } from './markdown';
+
+let renderMarkdown: (text: string) => string;
+
+beforeAll(async () => {
+  renderMarkdown = await getMarkdownRenderer();
+});
+
+/**
+ * Render markdown into the DOM the dialog injects with v-html.
+ * @param source - markdown text
+ * @returns element holding the rendered result
+ */
+function render(source: string): HTMLElement {
+  const host = document.createElement('div');
+
+  host.innerHTML = renderMarkdown(source);
+
+  return host;
+}
+
+describe('getMarkdownRenderer', () => {
+  describe('literal characters', () => {
+    it.each([
+      ['an apostrophe in text', 'it doesn\'t run', 'it doesn\'t run'],
+      ['ampersands in text', 'compare a && b', 'compare a && b'],
+      ['an angle bracket in text', 'a < b', 'a < b'],
+      ['an apostrophe in inline code', '`reading \'subscription\'`', 'reading \'subscription\''],
+      ['a quote in inline code', '`x === "active"`', 'x === "active"'],
+    ])('should show %s as written', (_case, source, expected) => {
+      expect(render(source).textContent).toContain(expected);
+    });
+  });
+
+  describe('block structure', () => {
+    it.each([
+      ['a list', '- one\n- two', 'ul li'],
+      ['a table', '| a |\n|---|\n| b |', 'table td'],
+    ])('should build %s', (_case, source, selector) => {
+      expect(render(source).querySelector(selector)).not.toBeNull();
+    });
+  });
+
+  describe('sanitising', () => {
+    it.each([
+      ['a remote image', '<img src="https://attacker.example/pixel.png">', 'img'],
+      ['an image smuggled out of inline code', '`</code><img src=x>`', 'img'],
+      ['a form', '<form action="https://attacker.example"></form>', 'form'],
+      ['a stylesheet', '<style>body { display: none }</style>', 'style'],
+    ])('should keep %s out of the DOM', (_case, source, selector) => {
+      expect(render(source).querySelector(selector)).toBeNull();
+    });
+
+    it('should drop a javascript: link target', () => {
+      const link = render('[click](javascript:alert(1))').querySelector('a');
+
+      expect(link?.getAttribute('href')).toBeNull();
+    });
+
+    it('should keep an ordinary link target', () => {
+      const link = render('[click](https://hawk.so)').querySelector('a');
+
+      expect(link?.getAttribute('href')).toBe('https://hawk.so');
+    });
+  });
+
+  describe('design system classes', () => {
+    it.each([
+      ['a paragraph', 'plain', 'p', 'text-p'],
+      ['a top-level heading', '# title', 'h1', 'text-h1'],
+      ['a second-level heading', '## title', 'h2', 'text-h2'],
+      ['inline code', 'an `identifier` here', 'code', 'text-monospaced'],
+    ])('should mark %s', (_case, source, selector, className) => {
+      expect(render(source).querySelector(selector)?.className).toBe(className);
+    });
+  });
+});
+
+describe('splitStringIntoTextAndCodeSegments', () => {
+  it('should read the language off a fence', () => {
+    const [segment] = splitStringIntoTextAndCodeSegments('```ts\nconst x = 1;\n```');
+
+    expect(segment).toMatchObject({ type: 'code',
+      lang: 'ts' });
+  });
+
+  it('should fall back to plaintext for a fence without a language', () => {
+    const [segment] = splitStringIntoTextAndCodeSegments('```\nconst x = 1;\n```');
+
+    expect(segment).toMatchObject({ type: 'code',
+      lang: 'plaintext' });
+  });
+
+  it('should leave an unclosed fence as text', () => {
+    const [segment] = splitStringIntoTextAndCodeSegments('```ts\nconst x = 1;');
+
+    expect(segment.type).toBe('text');
+  });
+});

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -96,19 +96,21 @@ export async function getMarkdownRenderer(): Promise<(text: string) => string> {
 
   const renderer = new Renderer();
 
-  renderer.heading = ({ tokens, depth }) => {
-    const text = marked.Parser.parseInline(tokens);
+  // this.parser, not marked.Parser: the static one builds a parser with the
+  // default renderer and never sees the overrides below.
+  renderer.heading = function ({ tokens, depth }) {
+    const text = this.parser.parseInline(tokens);
     const cls = depth === 1 ? 'text-h1' : depth === 2 ? 'text-h2' : 'text-ui-large';
 
     return `<h${depth} class="${cls}">${text}</h${depth}>`;
   };
 
-  renderer.paragraph = ({ tokens }) => {
-    return `<p class="text-p">${marked.Parser.parseInline(tokens)}</p>`;
+  renderer.paragraph = function ({ tokens }) {
+    return `<p class="text-p">${this.parser.parseInline(tokens)}</p>`;
   };
 
-  renderer.blockquote = ({ tokens }) => {
-    return `<blockquote class="text-blockquote">\n${marked.Parser.parse(tokens)}\n</blockquote>\n`;
+  renderer.blockquote = function ({ tokens }) {
+    return `<blockquote class="text-blockquote">\n${this.parser.parse(tokens)}\n</blockquote>\n`;
   };
 
   renderer.codespan = ({ text }) => {


### PR DESCRIPTION
The renderer overrides call `marked.Parser` statically, and the static parser builds its own with the default renderer. Tokens parsed through it never reach the overrides, so inline code inside a paragraph comes out without `text-monospaced` and escaped a second time:

```html
<code>reading &#39;subscription&#39;</code>
```

With the overrides in play:

```html
<code class="text-monospaced">reading 'subscription'</code>
```
