### PR TITLE
fix: keep UTM query params across navigation and auth redirects

### DIFF
--- a/config/tsconfig/base.json
+++ b/config/tsconfig/base.json
@@ -42,7 +42,6 @@
     "../../cypress/**/*.tsx"
   ],
   "exclude": [
-    "../../node_modules",
-    "../../src/**/*.test.ts"
+    "../../node_modules"
   ]
 }

--- a/config/tsconfig/base.json
+++ b/config/tsconfig/base.json
@@ -42,6 +42,7 @@
     "../../cypress/**/*.tsx"
   ],
   "exclude": [
-    "../../node_modules"
+    "../../node_modules",
+    "../../src/**/*.test.ts"
   ]
 }

--- a/cypress/integration/signup.test.ts
+++ b/cypress/integration/signup.test.ts
@@ -20,34 +20,25 @@ describe('Sign Up', () => {
       .should('eq', '/login');
   });
 
-  it('should keep UTM params when switching between signup and login', () => {
+  it('should store UTM from the landing URL in sessionStorage', () => {
     // Arrange
-    cy.visitHawk('sign-up?utm_source=google&utm_medium=cpc&utm_campaign=spring');
+    const path = 'sign-up?utm_source=google&utm_medium=cpc&utm_campaign=spring';
 
     // Act
-    cy.contains('Login')
-      .click();
+    cy.visitHawk(path);
 
     // Assert
-    cy.location('pathname')
-      .should('eq', '/login');
-    cy.location('search')
-      .should('include', 'utm_source=google')
-      .and('include', 'utm_medium=cpc')
-      .and('include', 'utm_campaign=spring');
-
-    // Act
-    cy.contains('Sign up')
-      .click();
-
-    // Assert
-    cy.location('pathname')
-      .should('eq', '/sign-up');
-    cy.location('search')
-      .should('include', 'utm_source=google');
+    cy.window()
+      .then((win) => {
+        expect(JSON.parse(win.sessionStorage.getItem('hawk_utm') ?? '{}')).to.deep.include({
+          source: 'google',
+          medium: 'cpc',
+          campaign: 'spring',
+        });
+      });
   });
 
-  it('should keep UTM params on login after visiting a protected page', () => {
+  it('should store UTM when redirected from a protected page to login', () => {
     // Arrange
     const path = '?utm_source=google&utm_campaign=spring';
 
@@ -57,12 +48,16 @@ describe('Sign Up', () => {
     // Assert
     cy.location('pathname')
       .should('eq', '/login');
-    cy.location('search')
-      .should('include', 'utm_source=google')
-      .and('include', 'utm_campaign=spring');
+    cy.window()
+      .then((win) => {
+        expect(JSON.parse(win.sessionStorage.getItem('hawk_utm') ?? '{}')).to.deep.include({
+          source: 'google',
+          campaign: 'spring',
+        });
+      });
   });
 
-  it('should send UTM params in signup after navigating through login', () => {
+  it('should send stored UTM in signup after navigating through login', () => {
     // Arrange
     cy.intercept('POST', '/graphql').as('graphql');
     cy.visitHawk('sign-up?utm_source=google&utm_campaign=spring');

--- a/cypress/integration/signup.test.ts
+++ b/cypress/integration/signup.test.ts
@@ -20,6 +20,70 @@ describe('Sign Up', () => {
       .should('eq', '/login');
   });
 
+  it('should keep UTM params when switching between signup and login', () => {
+    // Arrange
+    cy.visitHawk('sign-up?utm_source=google&utm_medium=cpc&utm_campaign=spring');
+
+    // Act
+    cy.contains('Login')
+      .click();
+
+    // Assert
+    cy.location('pathname')
+      .should('eq', '/login');
+    cy.location('search')
+      .should('include', 'utm_source=google')
+      .and('include', 'utm_medium=cpc')
+      .and('include', 'utm_campaign=spring');
+
+    // Act
+    cy.contains('Sign up')
+      .click();
+
+    // Assert
+    cy.location('pathname')
+      .should('eq', '/sign-up');
+    cy.location('search')
+      .should('include', 'utm_source=google');
+  });
+
+  it('should keep UTM params on login after visiting a protected page', () => {
+    // Arrange
+    const path = '?utm_source=google&utm_campaign=spring';
+
+    // Act
+    cy.visitHawk(path);
+
+    // Assert
+    cy.location('pathname')
+      .should('eq', '/login');
+    cy.location('search')
+      .should('include', 'utm_source=google')
+      .and('include', 'utm_campaign=spring');
+  });
+
+  it('should send UTM params in signup after navigating through login', () => {
+    // Arrange
+    cy.intercept('POST', '/graphql').as('graphql');
+    cy.visitHawk('sign-up?utm_source=google&utm_campaign=spring');
+    cy.contains('Login')
+      .click();
+    cy.contains('Sign up')
+      .click();
+
+    // Act
+    cy.register(user.email);
+
+    // Assert
+    cy.wait('@graphql')
+      .then((interception) => {
+        expect(interception.request.body.variables.utm).to.deep.include({
+          source: 'google',
+          campaign: 'spring',
+        });
+      });
+  });
+
   it('should open login page after signup', () => {
     cy.register(user.email);
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -120,11 +120,12 @@ Cypress.Commands.add('register', (email: string) => {
 });
 
 /**
- * Clears localStorage
+ * Clears localStorage and sessionStorage
  */
 Cypress.Commands.add('clearStorage', () => {
   cy.window()
     .then(win => {
       win.localStorage.clear();
+      win.sessionStorage.clear();
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.so",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "storybook": "vue-cli-service storybook:serve -p 6006 -c config/storybook -s ./public",
     "storybook:build": "vue-cli-service storybook:build -c config/storybook",
     "get-schema": "get-graphql-schema http://api-staging.hawk.so/graphql > schema.graphql",
+    "test": "node --experimental-strip-types --test src/components/utils/utm/utm.test.ts",
     "cy:run": "cypress run",
     "e2e:ci": "start-server-and-test serve 8080 cy:run"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "storybook": "vue-cli-service storybook:serve -p 6006 -c config/storybook -s ./public",
     "storybook:build": "vue-cli-service storybook:build -c config/storybook",
     "get-schema": "get-graphql-schema http://api-staging.hawk.so/graphql > schema.graphql",
-    "test": "node --experimental-strip-types --test src/components/utils/utm/utm.test.ts",
+    "test": "node --experimental-strip-types --test \"src/**/*.test.ts\"",
     "cy:run": "cypress run",
     "e2e:ci": "start-server-and-test serve 8080 cy:run"
   },

--- a/src/components/AppDemoBanner.vue
+++ b/src/components/AppDemoBanner.vue
@@ -23,6 +23,7 @@
 
 <script setup lang="ts">
 import { useDemo } from '../composables/useDemo';
+import { saveDemoUtm } from './utils/utm/utm';
 
 import UiButton from './utils/UiButton.vue';
 
@@ -37,19 +38,11 @@ const onDisableClick = (): void => {
 };
 
 const onRegisterClick = (): void => {
-  /* eslint-disable camelcase */
-  const registrationUtm = {
-    utm_source: 'demo',
-    utm_medium: 'demo_banner',
-    utm_campaign: 'demo_mode',
-    utm_content: 'registration_button',
-  };
-  /* eslint-enable camelcase */
+  saveDemoUtm();
 
   void disableDemo({
     redirectTo: {
       name: 'sign-up',
-      query: registrationUtm,
     },
   });
 };

--- a/src/components/auth/SignUp.vue
+++ b/src/components/auth/SignUp.vue
@@ -42,7 +42,7 @@ export default {
   },
   computed: {
     /**
-     * UTM captured on landing (including utm_demo)
+     * UTM captured on the first landing in this tab
      */
     utmData() {
       return getStoredUtm();

--- a/src/components/auth/SignUp.vue
+++ b/src/components/auth/SignUp.vue
@@ -3,7 +3,6 @@
     <FormComponent
       class="auth-page__form"
       :fields="fields"
-      :hidden-fields="hiddenFields"
       :submit-text="submitText"
       :message="message"
       :helper-text="isVisitedByInvite ? $t('authPages.inviteHelper') : null"
@@ -17,7 +16,7 @@ import FormComponent from './Form';
 import { SIGN_UP } from '../../store/modules/user/actionTypes';
 import { offlineErrorMessage } from '../../mixins/offlineErrorMessage';
 import notifier from 'codex-notifier';
-import { getUtmFromQuery } from '../utils/utm/utm';
+import { getStoredUtm } from '../utils/utm/utm';
 import { getCookie } from '../../utils';
 
 export default {
@@ -43,27 +42,10 @@ export default {
   },
   computed: {
     /**
-     * Extract and validate UTM parameters from route query
-     */
-    hiddenFields() {
-      const utm = getUtmFromQuery(this.$route.query);
-
-      if (!utm) {
-        return [];
-      }
-
-      return Object.entries(utm).map(([key, value]) => ({
-        name: `utm_${key}`,
-        value,
-        type: 'hidden',
-      }));
-    },
-
-    /**
-     * Get UTM data as object for API calls
+     * UTM captured on landing (including utm_demo)
      */
     utmData() {
-      return getUtmFromQuery(this.$route.query);
+      return getStoredUtm();
     },
 
     /**

--- a/src/components/auth/SignUp.vue
+++ b/src/components/auth/SignUp.vue
@@ -17,7 +17,7 @@ import FormComponent from './Form';
 import { SIGN_UP } from '../../store/modules/user/actionTypes';
 import { offlineErrorMessage } from '../../mixins/offlineErrorMessage';
 import notifier from 'codex-notifier';
-import { validateUtmParams } from '../utils/utm/utm';
+import { getUtmFromQuery } from '../utils/utm/utm';
 import { getCookie } from '../../utils';
 
 export default {
@@ -46,45 +46,24 @@ export default {
      * Extract and validate UTM parameters from route query
      */
     hiddenFields() {
-      const utmFields = [];
+      const utm = getUtmFromQuery(this.$route.query);
 
-      // Extract and validate each utm_ param individually
-      Object.entries(this.$route.query).forEach(([key, value]) => {
-        if (key.startsWith('utm_') && value) {
-          const cleanKey = key.replace('utm_', '');
+      if (!utm) {
+        return [];
+      }
 
-          // Validate single param
-          const singleParam = { [cleanKey]: value };
-          const validatedParam = validateUtmParams(singleParam);
-
-          // If this param is valid, add to fields
-          if (validatedParam[cleanKey]) {
-            utmFields.push({
-              name: key, // keep original utm_ prefix
-              value: validatedParam[cleanKey],
-              type: 'hidden',
-            });
-          }
-        }
-      });
-
-      return utmFields;
+      return Object.entries(utm).map(([key, value]) => ({
+        name: `utm_${key}`,
+        value,
+        type: 'hidden',
+      }));
     },
 
     /**
      * Get UTM data as object for API calls
      */
     utmData() {
-      const utmData = {};
-
-      this.hiddenFields.forEach((field) => {
-        // Remove 'utm_' prefix from field names
-        const cleanKey = field.name.replace('utm_', '');
-
-        utmData[cleanKey] = field.value;
-      });
-
-      return Object.keys(utmData).length > 0 ? utmData : undefined;
+      return getUtmFromQuery(this.$route.query);
     },
 
     /**

--- a/src/components/project/settings/General.vue
+++ b/src/components/project/settings/General.vue
@@ -98,17 +98,6 @@ export default defineComponent({
       required: true,
     },
   },
-  computed: {
-    workspace(): Workspace {
-      return this.$store.getters.getWorkspaceByProjectId(this.project.id);
-    },
-    currentMembership(): Member | undefined {
-      return this.$store.getters.getCurrentUserInWorkspace(this.workspace);
-    },
-    userCanEdit(): boolean {
-      return this.currentMembership ? (this.currentMembership as ConfirmedMember).isAdmin : false;
-    },
-  },
   data() {
     return {
       /**
@@ -123,6 +112,17 @@ export default defineComponent({
        */
       showSubmitButton: false,
     };
+  },
+  computed: {
+    workspace(): Workspace {
+      return this.$store.getters.getWorkspaceByProjectId(this.project.id);
+    },
+    currentMembership(): Member | undefined {
+      return this.$store.getters.getCurrentUserInWorkspace(this.workspace);
+    },
+    userCanEdit(): boolean {
+      return this.currentMembership ? (this.currentMembership as ConfirmedMember).isAdmin : false;
+    },
   },
   methods: {
     /**

--- a/src/components/utils/utm/utm.test.ts
+++ b/src/components/utils/utm/utm.test.ts
@@ -107,7 +107,7 @@ describe('UTM session storage', () => {
       });
     });
 
-    it('should keep the first campaign UTM if a later URL has different tags', () => {
+    it('should keep first-touch UTM and fill missing fields from later URLs', () => {
       // Arrange
       captureUtmFromQuery({
         utm_source: 'google',

--- a/src/components/utils/utm/utm.test.ts
+++ b/src/components/utils/utm/utm.test.ts
@@ -1,91 +1,45 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
-import { extractUtmQuery, getUtmFromQuery, mergeUtmIntoQuery } from './utm.ts';
+import { beforeEach, describe, it } from 'node:test';
+import {
+  captureUtmFromQuery,
+  getStoredUtm,
+  getUtmFromQuery,
+  saveDemoUtm,
+  UTM_STORAGE_KEY
+} from './utm.ts';
 
-describe('UTM query persistence', () => {
-  describe('extractUtmQuery', () => {
-    it('should keep only valid utm_* params', () => {
-      // Arrange
-      const query = {
-        utm_source: 'google',
-        utm_medium: 'cpc',
-        success: 'signup',
-        utm_invalid: 'nope',
-      };
+function createMemoryStorage(): Storage {
+  const data = new Map<string, string>();
 
-      // Act
-      const result = extractUtmQuery(query);
+  return {
+    get length() {
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+    getItem(key: string) {
+      return data.get(key) ?? null;
+    },
+    key(index: number) {
+      return [...data.keys()][index] ?? null;
+    },
+    removeItem(key: string) {
+      data.delete(key);
+    },
+    setItem(key: string, value: string) {
+      data.set(key, value);
+    },
+  };
+}
 
-      // Assert
-      assert.deepEqual(result, {
-        utm_source: 'google',
-        utm_medium: 'cpc',
-      });
-    });
-
-    it('should drop invalid UTM values', () => {
-      // Arrange
-      const query = { utm_source: 'google@bad' };
-
-      // Act
-      const result = extractUtmQuery(query);
-
-      // Assert
-      assert.deepEqual(result, {});
-    });
-  });
-
-  describe('mergeUtmIntoQuery', () => {
-    it('should copy UTM onto the next route when it has none', () => {
-      // Arrange
-      const toQuery = {
-        success: 'signup',
-        emailPrefilled: 'user@test.com',
-      };
-      const fromQuery = {
-        utm_source: 'google',
-        utm_campaign: 'spring',
-      };
-
-      // Act
-      const result = mergeUtmIntoQuery(toQuery, fromQuery);
-
-      // Assert
-      assert.deepEqual(result, {
-        success: 'signup',
-        emailPrefilled: 'user@test.com',
-        utm_source: 'google',
-        utm_campaign: 'spring',
-      });
-    });
-
-    it('should not overwrite UTM already present on the next route', () => {
-      // Arrange
-      const toQuery = { utm_source: 'newsletter' };
-      const fromQuery = { utm_source: 'google' };
-
-      // Act
-      const result = mergeUtmIntoQuery(toQuery, fromQuery);
-
-      // Assert
-      assert.equal(result, null);
-    });
-
-    it('should return null when there is no UTM to copy', () => {
-      // Arrange
-      const toQuery = { foo: 'bar' };
-      const fromQuery = { foo: 'baz' };
-
-      // Act
-      const result = mergeUtmIntoQuery(toQuery, fromQuery);
-
-      // Assert
-      assert.equal(result, null);
-    });
+describe('UTM session storage', () => {
+  beforeEach(() => {
+    globalThis.sessionStorage = createMemoryStorage();
   });
 
   describe('getUtmFromQuery', () => {
-    it('should return API-shaped UTM for signup', () => {
+    it('should return API-shaped UTM from query', () => {
       // Arrange
       const query = {
         utm_source: 'google',
@@ -105,10 +59,128 @@ describe('UTM query persistence', () => {
 
     it('should return undefined when query has no valid UTM', () => {
       // Arrange
-      const query = { success: 'signup' };
+      const query = {
+        success: 'signup',
+        utm_source: 'google@bad',
+      };
 
       // Act
       const result = getUtmFromQuery(query);
+
+      // Assert
+      assert.equal(result, undefined);
+    });
+  });
+
+  describe('captureUtmFromQuery', () => {
+    it('should save valid UTM from the landing URL', () => {
+      // Arrange
+      const query = {
+        utm_source: 'google',
+        utm_campaign: 'spring',
+      };
+
+      // Act
+      captureUtmFromQuery(query);
+
+      // Assert
+      assert.deepEqual(JSON.parse(sessionStorage.getItem(UTM_STORAGE_KEY) ?? ''), {
+        source: 'google',
+        campaign: 'spring',
+      });
+    });
+
+    it('should not clear stored UTM when the next URL has none', () => {
+      // Arrange
+      captureUtmFromQuery({
+        utm_source: 'google',
+      });
+
+      // Act
+      captureUtmFromQuery({
+        success: 'signup',
+      });
+
+      // Assert
+      assert.deepEqual(getStoredUtm(), {
+        source: 'google',
+      });
+    });
+
+    it('should keep the first campaign UTM if a later URL has different tags', () => {
+      // Arrange
+      captureUtmFromQuery({
+        utm_source: 'google',
+        utm_medium: 'cpc',
+      });
+
+      // Act
+      captureUtmFromQuery({
+        utm_source: 'facebook',
+        utm_campaign: 'later',
+      });
+
+      // Assert
+      assert.deepEqual(getStoredUtm(), {
+        source: 'google',
+        medium: 'cpc',
+        campaign: 'later',
+      });
+    });
+  });
+
+  describe('saveDemoUtm', () => {
+    it('should overwrite source with demo', () => {
+      // Arrange
+      captureUtmFromQuery({
+        utm_source: 'google',
+        utm_medium: 'cpc',
+      });
+
+      // Act
+      saveDemoUtm();
+
+      // Assert
+      assert.deepEqual(getStoredUtm(), {
+        source: 'demo',
+        medium: 'cpc',
+      });
+    });
+  });
+
+  describe('getStoredUtm', () => {
+    it('should return stored UTM for signup', () => {
+      // Arrange
+      captureUtmFromQuery({
+        utm_source: 'google',
+        utm_medium: 'cpc',
+      });
+
+      // Act
+      const result = getStoredUtm();
+
+      // Assert
+      assert.deepEqual(result, {
+        source: 'google',
+        medium: 'cpc',
+      });
+    });
+
+    it('should return undefined when nothing is stored', () => {
+      // Arrange
+      // Act
+      const result = getStoredUtm();
+
+      // Assert
+      assert.equal(result, undefined);
+    });
+
+    it('should return undefined for invalid stored JSON', () => {
+      // Arrange
+      sessionStorage.setItem(UTM_STORAGE_KEY, '{not-json');
+
+      // Act
+      const result = getStoredUtm();
 
       // Assert
       assert.equal(result, undefined);

--- a/src/components/utils/utm/utm.test.ts
+++ b/src/components/utils/utm/utm.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { extractUtmQuery, getUtmFromQuery, mergeUtmIntoQuery } from './utm.ts';
+
+describe('UTM query persistence', () => {
+  describe('extractUtmQuery', () => {
+    it('should keep only valid utm_* params', () => {
+      // Arrange
+      const query = {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        success: 'signup',
+        utm_invalid: 'nope',
+      };
+
+      // Act
+      const result = extractUtmQuery(query);
+
+      // Assert
+      assert.deepEqual(result, {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+      });
+    });
+
+    it('should drop invalid UTM values', () => {
+      // Arrange
+      const query = { utm_source: 'google@bad' };
+
+      // Act
+      const result = extractUtmQuery(query);
+
+      // Assert
+      assert.deepEqual(result, {});
+    });
+  });
+
+  describe('mergeUtmIntoQuery', () => {
+    it('should copy UTM onto the next route when it has none', () => {
+      // Arrange
+      const toQuery = { success: 'signup', emailPrefilled: 'user@test.com' };
+      const fromQuery = { utm_source: 'google', utm_campaign: 'spring' };
+
+      // Act
+      const result = mergeUtmIntoQuery(toQuery, fromQuery);
+
+      // Assert
+      assert.deepEqual(result, {
+        success: 'signup',
+        emailPrefilled: 'user@test.com',
+        utm_source: 'google',
+        utm_campaign: 'spring',
+      });
+    });
+
+    it('should not overwrite UTM already present on the next route', () => {
+      // Arrange
+      const toQuery = { utm_source: 'newsletter' };
+      const fromQuery = { utm_source: 'google' };
+
+      // Act
+      const result = mergeUtmIntoQuery(toQuery, fromQuery);
+
+      // Assert
+      assert.equal(result, null);
+    });
+
+    it('should return null when there is no UTM to copy', () => {
+      // Arrange
+      const toQuery = { foo: 'bar' };
+      const fromQuery = { foo: 'baz' };
+
+      // Act
+      const result = mergeUtmIntoQuery(toQuery, fromQuery);
+
+      // Assert
+      assert.equal(result, null);
+    });
+  });
+
+  describe('getUtmFromQuery', () => {
+    it('should return API-shaped UTM for signup', () => {
+      // Arrange
+      const query = { utm_source: 'google', utm_medium: 'cpc', foo: 'bar' };
+
+      // Act
+      const result = getUtmFromQuery(query);
+
+      // Assert
+      assert.deepEqual(result, {
+        source: 'google',
+        medium: 'cpc',
+      });
+    });
+
+    it('should return undefined when query has no valid UTM', () => {
+      // Arrange
+      const query = { success: 'signup' };
+
+      // Act
+      const result = getUtmFromQuery(query);
+
+      // Assert
+      assert.equal(result, undefined);
+    });
+  });
+});

--- a/src/components/utils/utm/utm.test.ts
+++ b/src/components/utils/utm/utm.test.ts
@@ -38,8 +38,14 @@ describe('UTM query persistence', () => {
   describe('mergeUtmIntoQuery', () => {
     it('should copy UTM onto the next route when it has none', () => {
       // Arrange
-      const toQuery = { success: 'signup', emailPrefilled: 'user@test.com' };
-      const fromQuery = { utm_source: 'google', utm_campaign: 'spring' };
+      const toQuery = {
+        success: 'signup',
+        emailPrefilled: 'user@test.com',
+      };
+      const fromQuery = {
+        utm_source: 'google',
+        utm_campaign: 'spring',
+      };
 
       // Act
       const result = mergeUtmIntoQuery(toQuery, fromQuery);
@@ -81,7 +87,11 @@ describe('UTM query persistence', () => {
   describe('getUtmFromQuery', () => {
     it('should return API-shaped UTM for signup', () => {
       // Arrange
-      const query = { utm_source: 'google', utm_medium: 'cpc', foo: 'bar' };
+      const query = {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        foo: 'bar',
+      };
 
       // Act
       const result = getUtmFromQuery(query);

--- a/src/components/utils/utm/utm.ts
+++ b/src/components/utils/utm/utm.ts
@@ -62,7 +62,7 @@ export function validateUtmParams(utm: any): Record<string, string> | undefined 
  */
 function firstQueryString(value: unknown): string | undefined {
   if (Array.isArray(value)) {
-    const found = value.find((item) => typeof item === 'string' && item.length > 0);
+    const found = value.find(item => typeof item === 'string' && item.length > 0);
 
     return typeof found === 'string' ? found : undefined;
   }

--- a/src/components/utils/utm/utm.ts
+++ b/src/components/utils/utm/utm.ts
@@ -20,6 +20,11 @@ const VALID_UTM_CHARACTERS = /^[a-zA-Z0-9\s\-_.]+$/;
 const MAX_UTM_VALUE_LENGTH = 50;
 
 /**
+ * Session storage key for captured UTM params
+ */
+export const UTM_STORAGE_KEY = 'hawk_utm';
+
+/**
  * Validates and filters UTM parameters
  * @param utm - UTM parameters to validate
  * @returns - filtered valid UTM parameters
@@ -75,10 +80,10 @@ function firstQueryString(value: unknown): string | undefined {
 }
 
 /**
- * Valid `utm_*` params from a route query, still prefixed
- * @param query - current or previous route query
+ * UTM object for API calls (`source`, `medium`, …) from a route query
+ * @param query - route query
  */
-export function extractUtmQuery(query: QueryLike): Record<string, string> {
+export function getUtmFromQuery(query: QueryLike): Record<string, string> | undefined {
   const unprefixed: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(query)) {
@@ -97,58 +102,77 @@ export function extractUtmQuery(query: QueryLike): Record<string, string> {
 
   const validated = validateUtmParams(unprefixed);
 
-  if (!validated) {
-    return {};
-  }
-
-  const prefixed: Record<string, string> = {};
-
-  for (const [key, value] of Object.entries(validated)) {
-    prefixed[`utm_${key}`] = value;
-  }
-
-  return prefixed;
-}
-
-/**
- * Copy UTM from the previous route when the next one has none.
- * Returns null when the query should stay as-is.
- * @param toQuery - destination route query
- * @param fromQuery - source route query
- */
-export function mergeUtmIntoQuery<T extends QueryLike>(toQuery: T, fromQuery: QueryLike): T | null {
-  if (Object.keys(extractUtmQuery(toQuery)).length > 0) {
-    return null;
-  }
-
-  const fromUtm = extractUtmQuery(fromQuery);
-
-  if (Object.keys(fromUtm).length === 0) {
-    return null;
-  }
-
-  return {
-    ...toQuery,
-    ...fromUtm,
-  };
-}
-
-/**
- * UTM object for API calls (`source`, `medium`, …) from a route query
- * @param query - route query
- */
-export function getUtmFromQuery(query: QueryLike): Record<string, string> | undefined {
-  const prefixed = extractUtmQuery(query);
-
-  if (Object.keys(prefixed).length === 0) {
+  if (!validated || Object.keys(validated).length === 0) {
     return undefined;
   }
 
-  const result: Record<string, string> = {};
+  return validated;
+}
 
-  for (const [key, value] of Object.entries(prefixed)) {
-    result[key.slice('utm_'.length)] = value;
+/**
+ * @param utm - validated UTM
+ */
+function writeUtm(utm: Record<string, string>): void {
+  try {
+    sessionStorage.setItem(UTM_STORAGE_KEY, JSON.stringify(utm));
+  } catch {
+    // sessionStorage may be unavailable
+  }
+}
+
+/**
+ * Stored UTM for signup
+ */
+export function getStoredUtm(): Record<string, string> | undefined {
+  try {
+    const raw = sessionStorage.getItem(UTM_STORAGE_KEY);
+
+    if (!raw) {
+      return undefined;
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    const validated = validateUtmParams(parsed);
+
+    if (!validated || Object.keys(validated).length === 0) {
+      return undefined;
+    }
+
+    return validated;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Persist valid UTM from the current URL. Campaign fields are first-touch.
+ * @param query - route query
+ */
+export function captureUtmFromQuery(query: QueryLike): void {
+  const incoming = getUtmFromQuery(query);
+
+  if (!incoming) {
+    return;
   }
 
-  return result;
+  const stored = getStoredUtm() ?? {};
+  const next: Record<string, string> = { ...stored };
+
+  for (const [key, value] of Object.entries(incoming)) {
+    if (stored[key] === undefined) {
+      next[key] = value;
+    }
+  }
+
+  writeUtm(next);
+}
+
+/**
+ * Registration from demo overwrites source
+ */
+export function saveDemoUtm(): void {
+  writeUtm({
+    ...getStoredUtm(),
+    source: 'demo',
+  });
 }

--- a/src/components/utils/utm/utm.ts
+++ b/src/components/utils/utm/utm.ts
@@ -1,4 +1,9 @@
 /**
+ * Route query-like object (vue-router LocationQuery is compatible)
+ */
+type QueryLike = Record<string, unknown>;
+
+/**
  * Valid UTM parameter keys
  */
 const VALID_UTM_KEYS = ['source', 'medium', 'campaign', 'content', 'term'];
@@ -46,6 +51,103 @@ export function validateUtmParams(utm: any): Record<string, string> | undefined 
     }
 
     result[key] = value;
+  }
+
+  return result;
+}
+
+/**
+ * First non-empty string from a query value (string or array)
+ * @param value - query value
+ */
+function firstQueryString(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    const found = value.find((item) => typeof item === 'string' && item.length > 0);
+
+    return typeof found === 'string' ? found : undefined;
+  }
+
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+
+  return undefined;
+}
+
+/**
+ * Valid `utm_*` params from a route query, still prefixed
+ * @param query - current or previous route query
+ */
+export function extractUtmQuery(query: QueryLike): Record<string, string> {
+  const unprefixed: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(query)) {
+    if (!key.startsWith('utm_')) {
+      continue;
+    }
+
+    const raw = firstQueryString(value);
+
+    if (raw === undefined) {
+      continue;
+    }
+
+    unprefixed[key.slice('utm_'.length)] = raw;
+  }
+
+  const validated = validateUtmParams(unprefixed);
+
+  if (!validated) {
+    return {};
+  }
+
+  const prefixed: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(validated)) {
+    prefixed[`utm_${key}`] = value;
+  }
+
+  return prefixed;
+}
+
+/**
+ * Copy UTM from the previous route when the next one has none.
+ * Returns null when the query should stay as-is.
+ * @param toQuery - destination route query
+ * @param fromQuery - source route query
+ */
+export function mergeUtmIntoQuery<T extends QueryLike>(toQuery: T, fromQuery: QueryLike): T | null {
+  if (Object.keys(extractUtmQuery(toQuery)).length > 0) {
+    return null;
+  }
+
+  const fromUtm = extractUtmQuery(fromQuery);
+
+  if (Object.keys(fromUtm).length === 0) {
+    return null;
+  }
+
+  return {
+    ...toQuery,
+    ...fromUtm,
+  };
+}
+
+/**
+ * UTM object for API calls (`source`, `medium`, …) from a route query
+ * @param query - route query
+ */
+export function getUtmFromQuery(query: QueryLike): Record<string, string> | undefined {
+  const prefixed = extractUtmQuery(query);
+
+  if (Object.keys(prefixed).length === 0) {
+    return undefined;
+  }
+
+  const result: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(prefixed)) {
+    result[key.slice('utm_'.length)] = value;
   }
 
   return result;

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,6 +6,7 @@ import AppShell from './components/AppShell.vue';
 import invitesHandler from './invitesHandler';
 import unsubscribeHandler from './unsubscribeHandler';
 import { loadAsyncComponent } from './utils';
+import { extractUtmQuery, mergeUtmIntoQuery } from './components/utils/utm/utm';
 
 /**
  * Empty component for routes that only use beforeEnter guards
@@ -363,13 +364,27 @@ const router = createRouter({
 router.beforeEach((to, from, next) => {
   const authRoutes = /^\/(login|sign-up|recover)/;
   const routesAvailableWithoutAuth = /^\/(join|unsubscribe)/;
+  const mergedQuery = mergeUtmIntoQuery(to.query, from.query);
+  const query = mergedQuery ?? to.query;
+  const utmQuery = extractUtmQuery(query);
 
   /**
    * Let `?demo=1` through before auth redirect — useDemo is not ready yet
    * (App mounts only after this navigation), and would never see the query
    * if we bounced to /login first.
    */
-  if (to.query.demo === '1') {
+  if (query.demo === '1') {
+    if (mergedQuery) {
+      next({
+        path: to.path,
+        query,
+        hash: to.hash,
+        replace: true,
+      });
+
+      return;
+    }
+
     next();
 
     return;
@@ -377,16 +392,31 @@ router.beforeEach((to, from, next) => {
 
   if (store.getters.isAuthenticated) {
     if (authRoutes.test(to.fullPath)) {
-      next('/');
+      next({
+        path: '/',
+        query: utmQuery,
+      });
 
       return;
     }
-  } else {
-    if (!authRoutes.test(to.fullPath) && !routesAvailableWithoutAuth.test(to.fullPath)) {
-      next('/login');
+  } else if (!authRoutes.test(to.fullPath) && !routesAvailableWithoutAuth.test(to.fullPath)) {
+    next({
+      path: '/login',
+      query: utmQuery,
+    });
 
-      return;
-    }
+    return;
+  }
+
+  if (mergedQuery) {
+    next({
+      path: to.path,
+      query,
+      hash: to.hash,
+      replace: true,
+    });
+
+    return;
   }
 
   next();

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,7 +6,7 @@ import AppShell from './components/AppShell.vue';
 import invitesHandler from './invitesHandler';
 import unsubscribeHandler from './unsubscribeHandler';
 import { loadAsyncComponent } from './utils';
-import { extractUtmQuery, mergeUtmIntoQuery } from './components/utils/utm/utm';
+import { captureUtmFromQuery } from './components/utils/utm/utm';
 
 /**
  * Empty component for routes that only use beforeEnter guards
@@ -364,27 +364,15 @@ const router = createRouter({
 router.beforeEach((to, from, next) => {
   const authRoutes = /^\/(login|sign-up|recover)/;
   const routesAvailableWithoutAuth = /^\/(join|unsubscribe)/;
-  const mergedQuery = mergeUtmIntoQuery(to.query, from.query);
-  const query = mergedQuery ?? to.query;
-  const utmQuery = extractUtmQuery(query);
+
+  captureUtmFromQuery(to.query);
 
   /**
    * Let `?demo=1` through before auth redirect — useDemo is not ready yet
    * (App mounts only after this navigation), and would never see the query
    * if we bounced to /login first.
    */
-  if (query.demo === '1') {
-    if (mergedQuery) {
-      next({
-        path: to.path,
-        query,
-        hash: to.hash,
-        replace: true,
-      });
-
-      return;
-    }
-
+  if (to.query.demo === '1') {
     next();
 
     return;
@@ -392,31 +380,16 @@ router.beforeEach((to, from, next) => {
 
   if (store.getters.isAuthenticated) {
     if (authRoutes.test(to.fullPath)) {
-      next({
-        path: '/',
-        query: utmQuery,
-      });
+      next('/');
 
       return;
     }
-  } else if (!authRoutes.test(to.fullPath) && !routesAvailableWithoutAuth.test(to.fullPath)) {
-    next({
-      path: '/login',
-      query: utmQuery,
-    });
+  } else {
+    if (!authRoutes.test(to.fullPath) && !routesAvailableWithoutAuth.test(to.fullPath)) {
+      next('/login');
 
-    return;
-  }
-
-  if (mergedQuery) {
-    next({
-      path: to.path,
-      query,
-      hash: to.hash,
-      replace: true,
-    });
-
-    return;
+      return;
+    }
   }
 
   next();


### PR DESCRIPTION
UTM was read only from the current URL, so auth redirects and in-app links dropped the tags before signUp.

Capture valid utm_* in the router guard (before the /login redirect) and store them in sessionStorage. Later URLs without UTM do not clear the store. Campaign fields are first-touch: existing keys are kept, missing ones can still be filled.

Signup reads the stored object. Register from the demo banner overwrites source with demo and leaves the rest. ?demo=1 is unchanged.