### PR TITLE
fix: hide entity color behind transparent PNG avatars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.so",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/components/utils/EntityImage.vue
+++ b/src/components/utils/EntityImage.vue
@@ -85,8 +85,8 @@ export default {
      * @returns {string} image background color (if image URL is not provided)
      */
     bgColor() {
-      if (this.isImageShowing) {
-        return 'none';
+      if (this.image) {
+        return 'transparent';
       }
       if (this.id) {
         return getEntityColor(this.id);


### PR DESCRIPTION
EntityImage used background-color: none after an image loaded. That is not valid CSS, so the browser kept the color filled in while the image was loading. Through PNG alpha that fill showed as a background around the icon.
Before:
<img width="506" height="185" alt="Снимок экрана — 2026-09-02 в 14 08 37" src="https://github.com/user-attachments/assets/26c0e995-01c5-4038-9995-ab41090fa744" />

After:
<img width="532" height="195" alt="Снимок экрана — 2026-09-02 в 14 04 00" src="https://github.com/user-attachments/assets/69c8bd95-6b04-41be-a74e-0428a995f12c" />
